### PR TITLE
Expose full member

### DIFF
--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -205,6 +205,23 @@ impl MlsGroup {
             .leaf(leaf_index)
             .map(|leaf| leaf.credential())
     }
+
+    /// Returns the [`Member`] corresponding to the given
+    /// leaf index. Returns `None` if the member can not be found in this group.
+    pub fn member_at(&self, leaf_index: LeafNodeIndex) -> Option<Member> {
+        self.group
+            .public_group()
+            // This will return an error if the member can't be found.
+            .leaf(leaf_index)
+            .map(|leaf_node| {
+                Member::new(
+                    leaf_index,
+                    leaf_node.encryption_key().as_slice().to_vec(),
+                    leaf_node.signature_key().as_slice().to_vec(),
+                    leaf_node.credential().clone(),
+                )
+            })
+    }
 }
 
 /// Helper `enum` that classifies the kind of remove operation. This can be used to


### PR DESCRIPTION
We need the `signature_key` of a given leaf node, because XMTP installation identities are based on this key, with the `credential` proving the linkage between this key and XMTP accounts.

Adding a method to expose the full `Member`, similar to the `members()` method above. Would love to just replace `member()`, but imagine this creates backwards compatibility issues.