### PR TITLE
Bring fork up to date with openmls main

### DIFF
--- a/.github/workflows/build_test_workspace.yml
+++ b/.github/workflows/build_test_workspace.yml
@@ -34,6 +34,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build workspace
-        run: cargo build --workspace --all-targets
+        run: cargo build --workspace --all-targets --exclude openmls-fuzz
       - name: Test workspace
         run: cargo test --workspace --all-targets --exclude=openmls --exclude openmls-fuzz

--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -8,6 +8,8 @@ use crate::extensions::{
     UnknownExtension,
 };
 
+use super::last_resort::LastResortExtension;
+
 fn vlbytes_len_len(length: usize) -> usize {
     if length < 0x40 {
         1
@@ -34,6 +36,7 @@ impl Size for Extension {
             Extension::RequiredCapabilities(e) => e.tls_serialized_len(),
             Extension::ExternalPub(e) => e.tls_serialized_len(),
             Extension::ExternalSenders(e) => e.tls_serialized_len(),
+            Extension::LastResort(e) => e.tls_serialized_len(),
             Extension::Unknown(_, e) => e.0.len(),
         };
 
@@ -65,6 +68,7 @@ impl Serialize for Extension {
             Extension::RequiredCapabilities(e) => e.tls_serialize(&mut extension_data),
             Extension::ExternalPub(e) => e.tls_serialize(&mut extension_data),
             Extension::ExternalSenders(e) => e.tls_serialize(&mut extension_data),
+            Extension::LastResort(e) => e.tls_serialize(&mut extension_data),
             Extension::Unknown(_, e) => extension_data
                 .write_all(e.0.as_slice())
                 .map(|_| e.0.len())
@@ -111,6 +115,9 @@ impl Deserialize for Extension {
             ExtensionType::ExternalSenders => Extension::ExternalSenders(
                 ExternalSendersExtension::tls_deserialize(&mut extension_data)?,
             ),
+            ExtensionType::LastResort => {
+                Extension::LastResort(LastResortExtension::tls_deserialize(&mut extension_data)?)
+            }
             ExtensionType::Unknown(unknown) => {
                 Extension::Unknown(unknown, UnknownExtension(extension_data.to_vec()))
             }

--- a/openmls/src/extensions/last_resort.rs
+++ b/openmls/src/extensions/last_resort.rs
@@ -1,0 +1,28 @@
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+use super::{Deserialize, Serialize};
+
+/// ```c
+/// // draft-ietf-mls-extensions-03
+/// struct {} LastResort;
+/// ```
+#[derive(
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsSize,
+    Default,
+)]
+pub struct LastResortExtension {}
+
+impl LastResortExtension {
+    /// Create a new `last_resort` extension.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -1,13 +1,13 @@
 //! # Extensions
 //!
 //! In MLS, extensions appear in the following places:
-//! - In [`KeyPackages`](`crate::key_packages`), to describe client capabilities and aspects of their
-//!   participation in the group.
+//! - In [`KeyPackages`](`crate::key_packages`), to describe client capabilities
+//!   and aspects of their participation in the group.
 //! - In the `GroupInfo`, to tell new members of a group what parameters are
-//!   being used by the group, and to provide any additional details required
-//!   to join the group.
-//! - In the `GroupContext` object, to ensure that all members of the group
-//!   have the same view of the parameters in use.
+//!   being used by the group, and to provide any additional details required to
+//!   join the group.
+//! - In the `GroupContext` object, to ensure that all members of the group have
+//!   the same view of the parameters in use.
 //!
 //! Note that `GroupInfo` and `GroupContext` are not exposed in OpenMLS' public
 //! API.
@@ -31,6 +31,7 @@ mod application_id_extension;
 mod codec;
 mod external_pub_extension;
 mod external_sender_extension;
+mod last_resort;
 mod ratchet_tree_extension;
 mod required_capabilities;
 use errors::*;
@@ -44,6 +45,7 @@ pub use external_pub_extension::ExternalPubExtension;
 pub use external_sender_extension::{
     ExternalSender, ExternalSendersExtension, SenderExtensionIndex,
 };
+pub use last_resort::LastResortExtension;
 pub use ratchet_tree_extension::RatchetTreeExtension;
 pub use required_capabilities::RequiredCapabilitiesExtension;
 
@@ -71,8 +73,8 @@ pub enum ExtensionType {
     /// application-defined identifier to a KeyPackage.
     ApplicationId,
 
-    /// The ratchet tree extensions provides the whole public state of the ratchet
-    /// tree.
+    /// The ratchet tree extensions provides the whole public state of the
+    /// ratchet tree.
     RatchetTree,
 
     /// The required capabilities extension defines the configuration of a group
@@ -86,6 +88,10 @@ pub enum ExtensionType {
     /// Group context extension that contains the credentials and signature keys
     /// of senders that are permitted to send external proposals to the group.
     ExternalSenders,
+
+    /// KeyPackage extension that marks a KeyPackage for use in a last resort
+    /// scenario.
+    LastResort,
 
     /// A currently unknown extension type.
     Unknown(u16),
@@ -125,6 +131,7 @@ impl From<u16> for ExtensionType {
             3 => ExtensionType::RequiredCapabilities,
             4 => ExtensionType::ExternalPub,
             5 => ExtensionType::ExternalSenders,
+            10 => ExtensionType::LastResort,
             unknown => ExtensionType::Unknown(unknown),
         }
     }
@@ -138,6 +145,7 @@ impl From<ExtensionType> for u16 {
             ExtensionType::RequiredCapabilities => 3,
             ExtensionType::ExternalPub => 4,
             ExtensionType::ExternalSenders => 5,
+            ExtensionType::LastResort => 10,
             ExtensionType::Unknown(unknown) => unknown,
         }
     }
@@ -153,6 +161,7 @@ impl ExtensionType {
                 | ExtensionType::RequiredCapabilities
                 | ExtensionType::ExternalPub
                 | ExtensionType::ExternalSenders
+                | ExtensionType::LastResort
         )
     }
 }
@@ -182,11 +191,14 @@ pub enum Extension {
     /// A [`RequiredCapabilitiesExtension`]
     RequiredCapabilities(RequiredCapabilitiesExtension),
 
-    /// A [`ExternalPubExtension`]
+    /// An [`ExternalPubExtension`]
     ExternalPub(ExternalPubExtension),
 
-    /// A [`ExternalPubExtension`]
+    /// An [`ExternalSendersExtension`]
     ExternalSenders(ExternalSendersExtension),
+
+    /// A [`LastResortExtension`]
+    LastResort(LastResortExtension),
 
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
@@ -234,7 +246,8 @@ impl Extensions {
 
     /// Create an extension list with multiple extensions.
     ///
-    /// This function will fail when the list of extensions contains duplicate extension types.
+    /// This function will fail when the list of extensions contains duplicate
+    /// extension types.
     pub fn from_vec(extensions: Vec<Extension>) -> Result<Self, InvalidExtensionError> {
         extensions.try_into()
     }
@@ -246,7 +259,8 @@ impl Extensions {
 
     /// Add an extension to the extension list.
     ///
-    /// Returns an error when there already is an extension with the same extension type.
+    /// Returns an error when there already is an extension with the same
+    /// extension type.
     pub fn add(&mut self, extension: Extension) -> Result<(), InvalidExtensionError> {
         if self.contains(extension.extension_type()) {
             return Err(InvalidExtensionError::Duplicate);
@@ -268,7 +282,8 @@ impl Extensions {
 
     /// Remove an extension from the extension list.
     ///
-    /// Returns the removed extension or `None` when there is no extension with the given extension type.
+    /// Returns the removed extension or `None` when there is no extension with
+    /// the given extension type.
     pub fn remove(&mut self, extension_type: ExtensionType) -> Option<Extension> {
         if let Some(pos) = self
             .unique
@@ -281,7 +296,8 @@ impl Extensions {
         }
     }
 
-    /// Returns `true` iff the extension list contains an extension with the given extension type.
+    /// Returns `true` iff the extension list contains an extension with the
+    /// given extension type.
     pub fn contains(&self, extension_type: ExtensionType) -> bool {
         self.unique
             .iter()
@@ -335,7 +351,8 @@ impl Extensions {
             })
     }
 
-    /// Get a reference to the [`RequiredCapabilitiesExtension`] if there is any.
+    /// Get a reference to the [`RequiredCapabilitiesExtension`] if there is
+    /// any.
     pub fn required_capabilities(&self) -> Option<&RequiredCapabilitiesExtension> {
         self.find_by_type(ExtensionType::RequiredCapabilities)
             .and_then(|e| match e {
@@ -389,8 +406,8 @@ impl Extension {
     }
 
     /// Get a reference to this extension as [`RequiredCapabilitiesExtension`].
-    /// Returns an [`ExtensionError::InvalidExtensionType`] error if called on an
-    /// [`Extension`] that's not a [`RequiredCapabilitiesExtension`].
+    /// Returns an [`ExtensionError::InvalidExtensionType`] error if called on
+    /// an [`Extension`] that's not a [`RequiredCapabilitiesExtension`].
     pub fn as_required_capabilities_extension(
         &self,
     ) -> Result<&RequiredCapabilitiesExtension, ExtensionError> {
@@ -403,8 +420,8 @@ impl Extension {
     }
 
     /// Get a reference to this extension as [`ExternalPubExtension`].
-    /// Returns an [`ExtensionError::InvalidExtensionType`] error if called on an
-    /// [`Extension`] that's not a [`ExternalPubExtension`].
+    /// Returns an [`ExtensionError::InvalidExtensionType`] error if called on
+    /// an [`Extension`] that's not a [`ExternalPubExtension`].
     pub fn as_external_pub_extension(&self) -> Result<&ExternalPubExtension, ExtensionError> {
         match self {
             Self::ExternalPub(e) => Ok(e),
@@ -415,8 +432,8 @@ impl Extension {
     }
 
     /// Get a reference to this extension as [`ExternalSendersExtension`].
-    /// Returns an [`ExtensionError::InvalidExtensionType`] error if called on an
-    /// [`Extension`] that's not a [`ExternalSendersExtension`].
+    /// Returns an [`ExtensionError::InvalidExtensionType`] error if called on
+    /// an [`Extension`] that's not a [`ExternalSendersExtension`].
     pub fn as_external_senders_extension(
         &self,
     ) -> Result<&ExternalSendersExtension, ExtensionError> {
@@ -437,6 +454,7 @@ impl Extension {
             Extension::RequiredCapabilities(_) => ExtensionType::RequiredCapabilities,
             Extension::ExternalPub(_) => ExtensionType::ExternalPub,
             Extension::ExternalSenders(_) => ExtensionType::ExternalSenders,
+            Extension::LastResort(_) => ExtensionType::LastResort,
             Extension::Unknown(kind, _) => ExtensionType::Unknown(*kind),
         }
     }

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -93,6 +93,11 @@ impl MlsGroupConfig {
         self.use_ratchet_tree_extension
     }
 
+    /// Returns the [`MlsGroupConfig`] required capabilities extension.
+    pub fn required_capabilities(&self) -> &RequiredCapabilitiesExtension {
+        &self.required_capabilities
+    }
+
     /// Returns the [`MlsGroupConfig`] sender ratchet configuration.
     pub fn sender_ratchet_configuration(&self) -> &SenderRatchetConfiguration {
         &self.sender_ratchet_configuration
@@ -175,6 +180,15 @@ impl MlsGroupConfigBuilder {
     /// Sets the `use_ratchet_tree_extension` property of the MlsGroupConfig.
     pub fn use_ratchet_tree_extension(mut self, use_ratchet_tree_extension: bool) -> Self {
         self.config.use_ratchet_tree_extension = use_ratchet_tree_extension;
+        self
+    }
+
+    /// Sets the `required_capabilities` property of the MlsGroupConfig.
+    pub fn required_capabilities(
+        mut self,
+        required_capabilities: RequiredCapabilitiesExtension,
+    ) -> Self {
+        self.config.required_capabilities = required_capabilities;
         self
     }
 

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -17,7 +17,8 @@ use crate::{
 impl MlsGroup {
     // === Group creation ===
 
-    /// Creates a new group with the creator as the only member (and a random group ID).
+    /// Creates a new group with the creator as the only member (and a random
+    /// group ID).
     ///
     /// This function removes the private key corresponding to the
     /// `key_package` from the key store.
@@ -36,7 +37,8 @@ impl MlsGroup {
         )
     }
 
-    /// Creates a new group with a given group ID with the creator as the only member.
+    /// Creates a new group with a given group ID with the creator as the only
+    /// member.
     pub fn new_with_group_id<KeyStore: OpenMlsKeyStore>(
         provider: &impl OpenMlsProvider<KeyStoreProvider = KeyStore>,
         signer: &impl Signer,
@@ -134,11 +136,15 @@ impl MlsGroup {
         };
 
         // Delete the [`KeyPackage`] and the corresponding private key from the
-        // key store
-        key_package_bundle
-            .key_package
-            .delete(provider)
-            .map_err(WelcomeError::KeyStoreError)?;
+        // key store, but only if it doesn't have a last resort extension.
+        if !key_package_bundle.key_package().last_resort() {
+            key_package_bundle
+                .key_package
+                .delete(provider)
+                .map_err(WelcomeError::KeyStoreError)?;
+        } else {
+            log::debug!("Key package has last resort extension, not deleting");
+        }
 
         let mut group = CoreGroup::new_from_welcome(
             welcome,
@@ -174,8 +180,8 @@ impl MlsGroup {
     /// group info. For more information on the external init process,
     /// please see Section 11.2.1 in the MLS specification.
     ///
-    /// Note: If there is a group member in the group with the same identity as us,
-    /// this will create a remove proposal.
+    /// Note: If there is a group member in the group with the same identity as
+    /// us, this will create a remove proposal.
     pub fn join_by_external_commit(
         provider: &impl OpenMlsProvider,
         signer: &impl Signer,

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -376,6 +376,11 @@ impl KeyPackage {
     pub fn hpke_init_key(&self) -> &HpkePublicKey {
         &self.payload.init_key
     }
+
+    /// Check if this KeyPackage is a last resort key package.
+    pub fn last_resort(&self) -> bool {
+        self.payload.extensions.contains(ExtensionType::LastResort)
+    }
 }
 
 /// Crate visible `KeyPackage` functions.

--- a/traits/src/traits.rs
+++ b/traits/src/traits.rs
@@ -13,7 +13,7 @@ pub mod types;
 ///
 /// An implementation of this trait must be passed in to the public OpenMLS API
 /// to perform randomness generation, cryptographic operations, and key storage.
-pub trait OpenMlsProvider: Send + Sync {
+pub trait OpenMlsProvider {
     type CryptoProvider: crypto::OpenMlsCrypto;
     type RandProvider: random::OpenMlsRand;
     type KeyStoreProvider: key_store::OpenMlsKeyStore;


### PR DESCRIPTION
This brings the fork up to date with main, which includes a change that relaxes the Send + Sync bound on `OpenMlsProvider`