### PR TITLE
Make proposals public

### DIFF
--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -418,7 +418,7 @@ impl StagedCommit {
     }
 
     /// Returns an iterator over all [`QueuedProposal`]s.
-    pub(crate) fn queued_proposals(&self) -> impl Iterator<Item = &QueuedProposal> {
+    pub fn queued_proposals(&self) -> impl Iterator<Item = &QueuedProposal> {
         self.staged_proposal_queue.queued_proposals()
     }
 


### PR DESCRIPTION
## Summary

I need to access the queued proposals in order to make sense of a staged commit and figure out what happened (members added/removed).

Should not have meaningful security impact to us, since this data is only ever accessed internally by our SDK.