### PR TITLE
PoC: Protected (Immutable) Metadata Extension

### DIFF
--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -8,7 +8,7 @@ use crate::extensions::{
     UnknownExtension,
 };
 
-use super::last_resort::LastResortExtension;
+use super::{last_resort::LastResortExtension, protected_metadata::ProtectedMetadata};
 
 fn vlbytes_len_len(length: usize) -> usize {
     if length < 0x40 {
@@ -37,6 +37,7 @@ impl Size for Extension {
             Extension::ExternalPub(e) => e.tls_serialized_len(),
             Extension::ExternalSenders(e) => e.tls_serialized_len(),
             Extension::LastResort(e) => e.tls_serialized_len(),
+            Extension::ProtectedMetadata(e) => e.tls_serialized_len(),
             Extension::Unknown(_, e) => e.0.len(),
         };
 
@@ -69,6 +70,7 @@ impl Serialize for Extension {
             Extension::ExternalPub(e) => e.tls_serialize(&mut extension_data),
             Extension::ExternalSenders(e) => e.tls_serialize(&mut extension_data),
             Extension::LastResort(e) => e.tls_serialize(&mut extension_data),
+            Extension::ProtectedMetadata(e) => e.tls_serialize(&mut extension_data),
             Extension::Unknown(_, e) => extension_data
                 .write_all(e.0.as_slice())
                 .map(|_| e.0.len())
@@ -118,6 +120,9 @@ impl Deserialize for Extension {
             ExtensionType::LastResort => {
                 Extension::LastResort(LastResortExtension::tls_deserialize(&mut extension_data)?)
             }
+            ExtensionType::ProtectedMetadata => Extension::ProtectedMetadata(
+                ProtectedMetadata::tls_deserialize(&mut extension_data)?,
+            ),
             ExtensionType::Unknown(unknown) => {
                 Extension::Unknown(unknown, UnknownExtension(extension_data.to_vec()))
             }

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -32,6 +32,7 @@ mod codec;
 mod external_pub_extension;
 mod external_sender_extension;
 mod last_resort;
+mod protected_metadata;
 mod ratchet_tree_extension;
 mod required_capabilities;
 use errors::*;
@@ -48,6 +49,8 @@ pub use external_sender_extension::{
 pub use last_resort::LastResortExtension;
 pub use ratchet_tree_extension::RatchetTreeExtension;
 pub use required_capabilities::RequiredCapabilitiesExtension;
+
+use self::protected_metadata::ProtectedMetadata;
 
 #[cfg(test)]
 mod test_extensions;
@@ -93,6 +96,10 @@ pub enum ExtensionType {
     /// scenario.
     LastResort,
 
+    /// Protected metadata extension for policies of the group. GroupContext
+    /// extension
+    ProtectedMetadata,
+
     /// A currently unknown extension type.
     Unknown(u16),
 }
@@ -132,6 +139,7 @@ impl From<u16> for ExtensionType {
             4 => ExtensionType::ExternalPub,
             5 => ExtensionType::ExternalSenders,
             10 => ExtensionType::LastResort,
+            11 => ExtensionType::ProtectedMetadata,
             unknown => ExtensionType::Unknown(unknown),
         }
     }
@@ -146,6 +154,7 @@ impl From<ExtensionType> for u16 {
             ExtensionType::ExternalPub => 4,
             ExtensionType::ExternalSenders => 5,
             ExtensionType::LastResort => 10,
+            ExtensionType::ProtectedMetadata => 11,
             ExtensionType::Unknown(unknown) => unknown,
         }
     }
@@ -162,6 +171,7 @@ impl ExtensionType {
                 | ExtensionType::ExternalPub
                 | ExtensionType::ExternalSenders
                 | ExtensionType::LastResort
+                | ExtensionType::ProtectedMetadata
         )
     }
 }
@@ -199,6 +209,9 @@ pub enum Extension {
 
     /// A [`LastResortExtension`]
     LastResort(LastResortExtension),
+
+    /// A [`ProtectedMetadata`] extension
+    ProtectedMetadata(ProtectedMetadata),
 
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
@@ -378,6 +391,15 @@ impl Extensions {
                 _ => None,
             })
     }
+
+    /// Get a reference to the [`ProtectedMetadata`] if there is any.
+    pub fn protected_metadata(&self) -> Option<&ProtectedMetadata> {
+        self.find_by_type(ExtensionType::ExternalSenders)
+            .and_then(|e| match e {
+                Extension::ProtectedMetadata(e) => Some(e),
+                _ => None,
+            })
+    }
 }
 
 impl Extension {
@@ -445,6 +467,18 @@ impl Extension {
         }
     }
 
+    /// Get a reference to this extension as [`ProtectedMetadata`].
+    /// Returns an [`ExtensionError::InvalidExtensionType`] error if called on
+    /// an [`Extension`] that's not a [`ProtectedMetadata`] extension.
+    pub fn as_protected_metadata_extension(&self) -> Result<&ProtectedMetadata, ExtensionError> {
+        match self {
+            Self::ProtectedMetadata(e) => Ok(e),
+            _ => Err(ExtensionError::InvalidExtensionType(
+                "This is not an ProtectedMetadata".into(),
+            )),
+        }
+    }
+
     /// Returns the [`ExtensionType`]
     #[inline]
     pub const fn extension_type(&self) -> ExtensionType {
@@ -455,6 +489,7 @@ impl Extension {
             Extension::ExternalPub(_) => ExtensionType::ExternalPub,
             Extension::ExternalSenders(_) => ExtensionType::ExternalSenders,
             Extension::LastResort(_) => ExtensionType::LastResort,
+            Extension::ProtectedMetadata(_) => ExtensionType::ProtectedMetadata,
             Extension::Unknown(kind, _) => ExtensionType::Unknown(*kind),
         }
     }


### PR DESCRIPTION
Here's a PoC version of the immutable metadata extension. Note that I decided to call it protected metadata instead because it's not really immutable.

The extension is implemented in `protected_metadata.rs` and also comes with a definition of the XMTP specific metadata. I don't know if you want that to live in here or move outside of OpenMLS. The test at the bottom of the file should show how to use the extension.

As mentioned offline, this does not follow the regular pattern of verifiable structs that we have in OpenMLS to enforce signature verification on the type level. In order to achieve this the handling of extensions must be changed more widely.

Please give this a go and let me know if it works for you or if we should change it.
Beginning of next year we will then implement it more robustly, but this should get you started on using the metadata and enforcing the policies.