### PR TITLE
Add Simple Metadata Extension

### DIFF
--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -9,8 +9,7 @@ use crate::extensions::{
 };
 
 use super::{
-    last_resort::LastResortExtension, mutable_metadata::MutableMetadata,
-    protected_metadata::ProtectedMetadata,
+    last_resort::LastResortExtension, metadata::Metadata, protected_metadata::ProtectedMetadata,
 };
 
 fn vlbytes_len_len(length: usize) -> usize {
@@ -41,7 +40,7 @@ impl Size for Extension {
             Extension::ExternalSenders(e) => e.tls_serialized_len(),
             Extension::LastResort(e) => e.tls_serialized_len(),
             Extension::ProtectedMetadata(e) => e.tls_serialized_len(),
-            Extension::MutableMetadata(e) => e.tls_serialized_len(),
+            Extension::Metadata(e) => e.tls_serialized_len(),
             Extension::Unknown(_, e) => e.0.len(),
         };
 
@@ -75,7 +74,7 @@ impl Serialize for Extension {
             Extension::ExternalSenders(e) => e.tls_serialize(&mut extension_data),
             Extension::LastResort(e) => e.tls_serialize(&mut extension_data),
             Extension::ProtectedMetadata(e) => e.tls_serialize(&mut extension_data),
-            Extension::MutableMetadata(e) => e.tls_serialize(&mut extension_data),
+            Extension::Metadata(e) => e.tls_serialize(&mut extension_data),
             Extension::Unknown(_, e) => extension_data
                 .write_all(e.0.as_slice())
                 .map(|_| e.0.len())
@@ -128,8 +127,8 @@ impl Deserialize for Extension {
             ExtensionType::ProtectedMetadata => Extension::ProtectedMetadata(
                 ProtectedMetadata::tls_deserialize(&mut extension_data)?,
             ),
-            ExtensionType::MutableMetadata => {
-                Extension::MutableMetadata(MutableMetadata::tls_deserialize(&mut extension_data)?)
+            ExtensionType::Metadata => {
+                Extension::Metadata(Metadata::tls_deserialize(&mut extension_data)?)
             }
             ExtensionType::Unknown(unknown) => {
                 Extension::Unknown(unknown, UnknownExtension(extension_data.to_vec()))

--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -8,7 +8,10 @@ use crate::extensions::{
     UnknownExtension,
 };
 
-use super::{last_resort::LastResortExtension, protected_metadata::ProtectedMetadata};
+use super::{
+    last_resort::LastResortExtension, mutable_metadata::MutableMetadata,
+    protected_metadata::ProtectedMetadata,
+};
 
 fn vlbytes_len_len(length: usize) -> usize {
     if length < 0x40 {
@@ -38,6 +41,7 @@ impl Size for Extension {
             Extension::ExternalSenders(e) => e.tls_serialized_len(),
             Extension::LastResort(e) => e.tls_serialized_len(),
             Extension::ProtectedMetadata(e) => e.tls_serialized_len(),
+            Extension::MutableMetadata(e) => e.tls_serialized_len(),
             Extension::Unknown(_, e) => e.0.len(),
         };
 
@@ -71,6 +75,7 @@ impl Serialize for Extension {
             Extension::ExternalSenders(e) => e.tls_serialize(&mut extension_data),
             Extension::LastResort(e) => e.tls_serialize(&mut extension_data),
             Extension::ProtectedMetadata(e) => e.tls_serialize(&mut extension_data),
+            Extension::MutableMetadata(e) => e.tls_serialize(&mut extension_data),
             Extension::Unknown(_, e) => extension_data
                 .write_all(e.0.as_slice())
                 .map(|_| e.0.len())
@@ -123,6 +128,9 @@ impl Deserialize for Extension {
             ExtensionType::ProtectedMetadata => Extension::ProtectedMetadata(
                 ProtectedMetadata::tls_deserialize(&mut extension_data)?,
             ),
+            ExtensionType::MutableMetadata => {
+                Extension::MutableMetadata(MutableMetadata::tls_deserialize(&mut extension_data)?)
+            }
             ExtensionType::Unknown(unknown) => {
                 Extension::Unknown(unknown, UnknownExtension(extension_data.to_vec()))
             }

--- a/openmls/src/extensions/metadata.rs
+++ b/openmls/src/extensions/metadata.rs
@@ -1,6 +1,8 @@
 use super::{Deserialize, Serialize};
 use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
+/// Metadata is an extension that keeps arbitrary application-specific metadata, in the form of a
+/// byte sequence. The application is responsible for specifying a format and parsing the contents.
 #[derive(
     PartialEq, Eq, Clone, Debug, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
@@ -9,10 +11,12 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    /// Create a new [`Metadata`] extension.
     pub fn new(metadata: Vec<u8>) -> Self {
         Self { metadata }
     }
 
+    /// Get the metadata bytes.
     pub fn metadata(&self) -> &Vec<u8> {
         &self.metadata
     }

--- a/openmls/src/extensions/metadata.rs
+++ b/openmls/src/extensions/metadata.rs
@@ -4,11 +4,11 @@ use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 #[derive(
     PartialEq, Eq, Clone, Debug, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
-pub struct MutableMetadata {
+pub struct Metadata {
     metadata: Vec<u8>,
 }
 
-impl MutableMetadata {
+impl Metadata {
     pub fn new(metadata: Vec<u8>) -> Self {
         Self { metadata }
     }

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -51,9 +51,8 @@ pub use last_resort::LastResortExtension;
 pub use ratchet_tree_extension::RatchetTreeExtension;
 pub use required_capabilities::RequiredCapabilitiesExtension;
 
-pub use protected_metadata::ProtectedMetadata;
-
 pub use metadata::Metadata;
+pub use protected_metadata::ProtectedMetadata;
 
 #[cfg(test)]
 mod test_extensions;
@@ -103,6 +102,7 @@ pub enum ExtensionType {
     /// extension
     ProtectedMetadata,
 
+    /// Metadata extension for policies and other metadata. GroupContext Extension.
     Metadata,
 
     /// A currently unknown extension type.
@@ -221,6 +221,7 @@ pub enum Extension {
     /// A [`ProtectedMetadata`] extension
     ProtectedMetadata(ProtectedMetadata),
 
+    // A [`Metadata`] extension
     Metadata(Metadata),
 
     /// A currently unknown extension.

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -32,7 +32,7 @@ mod codec;
 mod external_pub_extension;
 mod external_sender_extension;
 mod last_resort;
-mod mutable_metadata;
+mod metadata;
 mod protected_metadata;
 mod ratchet_tree_extension;
 mod required_capabilities;
@@ -53,7 +53,7 @@ pub use required_capabilities::RequiredCapabilitiesExtension;
 
 pub use protected_metadata::ProtectedMetadata;
 
-use self::mutable_metadata::MutableMetadata;
+pub use metadata::Metadata;
 
 #[cfg(test)]
 mod test_extensions;
@@ -103,7 +103,7 @@ pub enum ExtensionType {
     /// extension
     ProtectedMetadata,
 
-    MutableMetadata,
+    Metadata,
 
     /// A currently unknown extension type.
     Unknown(u16),
@@ -145,7 +145,7 @@ impl From<u16> for ExtensionType {
             5 => ExtensionType::ExternalSenders,
             10 => ExtensionType::LastResort,
             11 => ExtensionType::ProtectedMetadata,
-            0xf001 => ExtensionType::MutableMetadata,
+            0xf001 => ExtensionType::Metadata,
             unknown => ExtensionType::Unknown(unknown),
         }
     }
@@ -161,7 +161,7 @@ impl From<ExtensionType> for u16 {
             ExtensionType::ExternalSenders => 5,
             ExtensionType::LastResort => 10,
             ExtensionType::ProtectedMetadata => 11,
-            ExtensionType::MutableMetadata => 0xf001,
+            ExtensionType::Metadata => 0xf001,
             ExtensionType::Unknown(unknown) => unknown,
         }
     }
@@ -179,7 +179,7 @@ impl ExtensionType {
                 | ExtensionType::ExternalSenders
                 | ExtensionType::LastResort
                 | ExtensionType::ProtectedMetadata
-                | ExtensionType::MutableMetadata
+                | ExtensionType::Metadata
         )
     }
 }
@@ -221,7 +221,7 @@ pub enum Extension {
     /// A [`ProtectedMetadata`] extension
     ProtectedMetadata(ProtectedMetadata),
 
-    MutableMetadata(MutableMetadata),
+    Metadata(Metadata),
 
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
@@ -410,6 +410,14 @@ impl Extensions {
                 _ => None,
             })
     }
+
+    pub fn metadata(&self) -> Option<&Metadata> {
+        self.find_by_type(ExtensionType::Metadata)
+            .and_then(|e| match e {
+                Extension::Metadata(e) => Some(e),
+                _ => None,
+            })
+    }
 }
 
 impl Extension {
@@ -500,7 +508,7 @@ impl Extension {
             Extension::ExternalSenders(_) => ExtensionType::ExternalSenders,
             Extension::LastResort(_) => ExtensionType::LastResort,
             Extension::ProtectedMetadata(_) => ExtensionType::ProtectedMetadata,
-            Extension::MutableMetadata(_) => ExtensionType::MutableMetadata,
+            Extension::Metadata(_) => ExtensionType::Metadata,
             Extension::Unknown(kind, _) => ExtensionType::Unknown(*kind),
         }
     }

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -32,6 +32,7 @@ mod codec;
 mod external_pub_extension;
 mod external_sender_extension;
 mod last_resort;
+mod mutable_metadata;
 mod protected_metadata;
 mod ratchet_tree_extension;
 mod required_capabilities;
@@ -51,6 +52,8 @@ pub use ratchet_tree_extension::RatchetTreeExtension;
 pub use required_capabilities::RequiredCapabilitiesExtension;
 
 pub use protected_metadata::ProtectedMetadata;
+
+use self::mutable_metadata::MutableMetadata;
 
 #[cfg(test)]
 mod test_extensions;
@@ -100,6 +103,8 @@ pub enum ExtensionType {
     /// extension
     ProtectedMetadata,
 
+    MutableMetadata,
+
     /// A currently unknown extension type.
     Unknown(u16),
 }
@@ -140,6 +145,7 @@ impl From<u16> for ExtensionType {
             5 => ExtensionType::ExternalSenders,
             10 => ExtensionType::LastResort,
             11 => ExtensionType::ProtectedMetadata,
+            0xf001 => ExtensionType::MutableMetadata,
             unknown => ExtensionType::Unknown(unknown),
         }
     }
@@ -155,6 +161,7 @@ impl From<ExtensionType> for u16 {
             ExtensionType::ExternalSenders => 5,
             ExtensionType::LastResort => 10,
             ExtensionType::ProtectedMetadata => 11,
+            ExtensionType::MutableMetadata => 0xf001,
             ExtensionType::Unknown(unknown) => unknown,
         }
     }
@@ -172,6 +179,7 @@ impl ExtensionType {
                 | ExtensionType::ExternalSenders
                 | ExtensionType::LastResort
                 | ExtensionType::ProtectedMetadata
+                | ExtensionType::MutableMetadata
         )
     }
 }
@@ -212,6 +220,8 @@ pub enum Extension {
 
     /// A [`ProtectedMetadata`] extension
     ProtectedMetadata(ProtectedMetadata),
+
+    MutableMetadata(MutableMetadata),
 
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
@@ -490,6 +500,7 @@ impl Extension {
             Extension::ExternalSenders(_) => ExtensionType::ExternalSenders,
             Extension::LastResort(_) => ExtensionType::LastResort,
             Extension::ProtectedMetadata(_) => ExtensionType::ProtectedMetadata,
+            Extension::MutableMetadata(_) => ExtensionType::MutableMetadata,
             Extension::Unknown(kind, _) => ExtensionType::Unknown(*kind),
         }
     }

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -144,8 +144,8 @@ impl From<u16> for ExtensionType {
             4 => ExtensionType::ExternalPub,
             5 => ExtensionType::ExternalSenders,
             10 => ExtensionType::LastResort,
-            11 => ExtensionType::ProtectedMetadata,
             0xf001 => ExtensionType::Metadata,
+            0xf002 => ExtensionType::ProtectedMetadata,
             unknown => ExtensionType::Unknown(unknown),
         }
     }
@@ -160,8 +160,8 @@ impl From<ExtensionType> for u16 {
             ExtensionType::ExternalPub => 4,
             ExtensionType::ExternalSenders => 5,
             ExtensionType::LastResort => 10,
-            ExtensionType::ProtectedMetadata => 11,
             ExtensionType::Metadata => 0xf001,
+            ExtensionType::ProtectedMetadata => 0xf002,
             ExtensionType::Unknown(unknown) => unknown,
         }
     }

--- a/openmls/src/extensions/mutable_metadata.rs
+++ b/openmls/src/extensions/mutable_metadata.rs
@@ -1,0 +1,19 @@
+use super::{Deserialize, Serialize};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+#[derive(
+    PartialEq, Eq, Clone, Debug, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+)]
+pub struct MutableMetadata {
+    metadata: Vec<u8>,
+}
+
+impl MutableMetadata {
+    pub fn new(metadata: Vec<u8>) -> Self {
+        Self { metadata }
+    }
+
+    pub fn metadata(&self) -> &Vec<u8> {
+        &self.metadata
+    }
+}

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -251,6 +251,45 @@ fn required_capabilities() {
 }
 
 #[apply(ciphersuites_and_providers)]
+fn test_metadata(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
+    // Create credentials and keys
+    //let (alice_credential_with_key, alice_signature_keys) =
+    let alice_credential_with_key_and_signer = tests::utils::generate_credential_with_key(
+        b"Alice".into(),
+        ciphersuite.signature_algorithm(),
+        provider,
+    );
+
+    // example metadata (opaque data -- test hex string is "1cedc0ffee")
+    let metadata = vec![0x1c, 0xed, 0xc0, 0xff, 0xee];
+    let ext = Extension::Metadata(Metadata::new(metadata.clone()));
+    let extensions = Extensions::from_vec(vec![ext]).expect("could not build extensions struct");
+
+    let config = MlsGroupConfig::builder()
+        .group_context_extensions(extensions)
+        .build();
+
+    // === Alice creates a group with the ratchet tree extension ===
+    let alice_group = MlsGroup::new(
+        provider,
+        &alice_credential_with_key_and_signer.signer,
+        &config,
+        alice_credential_with_key_and_signer
+            .credential_with_key
+            .clone(),
+    )
+    .expect("failed to build group");
+
+    let got_metadata = alice_group
+        .export_group_context()
+        .extensions()
+        .metadata()
+        .expect("failed to read group metadata");
+
+    assert_eq!(got_metadata.metadata(), &metadata);
+}
+
+#[apply(ciphersuites_and_providers)]
 fn last_resort_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
     let last_resort = Extension::LastResort(LastResortExtension::default());
 


### PR DESCRIPTION
This PR adds the Metadata extension, which contains a simple byte sequence. This is a simplification of ProtectedMetadata, which had provisions to sign the metadata content. In both extensions, interpreting the contents of the byte sequence is up to the application.