### PR TITLE
Expose encryption methods

### DIFF
--- a/openmls/src/ciphersuite/hpke.rs
+++ b/openmls/src/ciphersuite/hpke.rs
@@ -45,7 +45,7 @@ use super::LABEL_PREFIX;
 
 /// HPKE labeled encryption errors.
 #[derive(Error, Debug, PartialEq, Clone)]
-pub(crate) enum Error {
+pub enum Error {
     /// Error while serializing content. This should only happen if a bounds check was missing.
     #[error(
         "Error while serializing content. This should only happen if a bounds check was missing."

--- a/openmls/src/ciphersuite/hpke.rs
+++ b/openmls/src/ciphersuite/hpke.rs
@@ -74,6 +74,7 @@ pub struct EncryptContext {
     context: VLBytes,
 }
 
+// Context for HPKE encryption
 impl EncryptContext {
     /// Create a new [`EncryptContext`] from a string label and the content bytes.
     pub fn new(label: &str, context: VLBytes) -> Self {

--- a/openmls/src/ciphersuite/hpke.rs
+++ b/openmls/src/ciphersuite/hpke.rs
@@ -68,6 +68,7 @@ impl From<CryptoError> for Error {
     }
 }
 
+// Context for HPKE encryption
 #[derive(Debug, Clone, TlsSerialize, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 pub struct EncryptContext {
     label: VLBytes,

--- a/openmls/src/ciphersuite/hpke.rs
+++ b/openmls/src/ciphersuite/hpke.rs
@@ -90,7 +90,7 @@ impl From<(&str, &[u8])> for EncryptContext {
 }
 
 /// Encrypt to an HPKE key with a label.
-pub(crate) fn encrypt_with_label(
+pub fn encrypt_with_label(
     public_key: &[u8],
     label: &str,
     context: &[u8],
@@ -123,7 +123,7 @@ pub(crate) fn encrypt_with_label(
 }
 
 /// Decrypt with HPKE and label.
-pub(crate) fn decrypt_with_label(
+pub fn decrypt_with_label(
     private_key: &[u8],
     label: &str,
     context: &[u8],

--- a/openmls/src/ciphersuite/hpke.rs
+++ b/openmls/src/ciphersuite/hpke.rs
@@ -68,14 +68,14 @@ impl From<CryptoError> for Error {
     }
 }
 
-// Context for HPKE encryption
+/// Context for HPKE encryption
 #[derive(Debug, Clone, TlsSerialize, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 pub struct EncryptContext {
     label: VLBytes,
     context: VLBytes,
 }
 
-// Context for HPKE encryption
+/// Context for HPKE encryption
 impl EncryptContext {
     /// Create a new [`EncryptContext`] from a string label and the content bytes.
     pub fn new(label: &str, context: VLBytes) -> Self {

--- a/openmls/src/ciphersuite/mod.rs
+++ b/openmls/src/ciphersuite/mod.rs
@@ -16,7 +16,7 @@ use std::hash::Hash;
 
 mod aead;
 mod codec;
-pub(crate) mod hpke;
+pub mod hpke;
 mod kdf_label;
 mod mac;
 mod reuse_guard;


### PR DESCRIPTION
In order to encrypt welcome messages we are going to use the existing HPKE infrastructure in OpenMLS. Many of these functions and types are currently private, so this PR makes them public to allow `libxmtp` to make use of them.

More info [here](https://github.com/xmtp/libxmtp/issues/423#issuecomment-1899085377)