### PR TITLE
Review

### DIFF
--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -124,7 +124,7 @@ impl CoreGroup {
                     FramedContentBody::Proposal(_) => {
                         Err(ProcessMessageError::UnsupportedProposalType)
                     }
-                    FramedContentBody::Commit(_) => unimplemented!(),
+                    FramedContentBody::Commit(_) => unimplemented!(), // NOTE: Should just be an error.
                 }
             }
         }

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -226,7 +226,7 @@ impl CoreGroup {
                 // Even if there is no path, we have to update the group context.
                 diff.update_group_context(
                     provider.crypto(),
-                    apply_proposals_values.extensions.clone(),
+                    apply_proposals_values.extensions.clone(), // NOTE: Could/should be None.
                 )?;
 
                 (

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -186,6 +186,7 @@ impl KeyPackageIn {
 
         // Ensure validity of the life time extension in the leaf node.
         if let Some(life_time) = key_package.payload.leaf_node.life_time() {
+            // NOTE: This must only be verified optionally.
             if !life_time.is_valid() {
                 return Err(KeyPackageVerifyError::InvalidLifetime);
             }


### PR DESCRIPTION
These are the missing/incorrect validations:

- [ ] If there are any non-default proposal types, verify that all **receivers** support that proposal type.
- [ ] If a commit is from a `new_member_commit` sender:
   - [ ] Verify at most one Remove proposal.
   - [ ] If Remove is present, verify new and old credentials represent the same client.
   - [ ] If Remove is not present, verify credential does not represent a client already in the group.
- [ ] If commit is from a member:
   - [ ] Verify no Update or Remove proposal applies to the same leaf as another.
   - [ ] Verify Add proposals represent distinct clients.
   - [ ] Verify no Add proposal represents a client already in the group, unless there's a corresponding Remove proposal.
   - [ ] If a ReInit is present, verify it is the only proposal.
   - [ ] Verify there's no ExternalInit proposal.
- [ ] If `path` is populated:
   - [ ] Verify parent hash is set correctly.
   - [ ] Verify that none of the public keys of the UpdatePath appear in any node of the ratchet tree.
- [ ] For Add proposals, verifying the expiration should be optional.
- [ ] For Update proposals, verify new and old credentials represent the same client.
- [ ] For GroupContextExtension proposals:
   - [ ] Verify all members of the **new group** indicate support for all extensions.
   - [ ] If there is a RequiredCapabilities extension, verify all members of the **new group** indicate support for required capabilities.
- [ ] If there's no GroupContextExtension proposal:
   - [ ] Verify all members of the **new group** indicate support for all extensions in GroupContext.
   - [ ] If there is a RequiredCapabilities extension in the GroupContext, verify all members of the **new group** indicate support for required capabilities.
- [ ] Verify uniqueness in the **new group** of all members' `signature_key` and `encryption_key`.
- [ ] Verify that each LeafNode's credential type is supported by all members of the **new group**.

Where a validation has been implemented incorrectly, I tried to leave a note in the code.