### PR TITLE
Make extensions function public for GCE proposal

### DIFF
--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -499,7 +499,7 @@ impl GroupContextExtensionProposal {
     }
 
     /// Get the extensions of the proposal
-    pub(crate) fn extensions(&self) -> &Extensions {
+    pub fn extensions(&self) -> &Extensions {
         &self.extensions
     }
 }


### PR DESCRIPTION
This is related to libxmtp Mutable Metadata:

See https://github.com/xmtp/libxmtp/issues/548 for more info.

Related PR's:

- proto 2: https://github.com/xmtp/proto/pull/161
- libxmtp Part 3: https://github.com/xmtp/libxmtp/pull/677