### PR TITLE
Repro missing epochs

### DIFF
--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -305,6 +305,10 @@ impl CoreGroup {
         if let Some(message_secrets) = self.merge_commit(provider, staged_commit)? {
             self.message_secrets_store
                 .add(past_epoch, message_secrets, leaves);
+            provider
+                .storage()
+                .write_message_secrets(self.group_id(), &self.message_secrets_store)
+                .map_err(|err| MergeCommitError::StorageError(err))?;
         }
         // Empty the proposal store
         proposal_store.empty();

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -5,6 +5,7 @@ use crate::{
     framing::{MessageDecryptionError, MlsMessageIn, ProcessedMessageContent},
     group::*,
 };
+use openmls_traits::OpenMlsProvider;
 
 #[openmls_test::openmls_test]
 fn test_past_secrets_in_group(
@@ -135,9 +136,11 @@ fn test_past_secrets_in_group(
                 ),)
             ));
         }
-
         // The last messages should not fail
         for application_message in application_messages.iter().skip(max_epochs / 2) {
+            let mut bob_group = MlsGroup::load(provider.storage(), bob_group.group_id())
+                .expect("reload group")
+                .unwrap();
             let bob_processed_message = bob_group
                 .process_message(provider, application_message.clone())
                 .expect("An unexpected error occurred.");

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -123,7 +123,6 @@ fn test_past_secrets_in_group(
         }
 
         // === Test application messages from older epochs ===
-
         // The first messages should fail
         for application_message in application_messages.iter().take(max_epochs / 2) {
             let err = bob_group
@@ -136,11 +135,11 @@ fn test_past_secrets_in_group(
                 ),)
             ));
         }
+        let mut bob_group = MlsGroup::load(provider.storage(), bob_group.group_id())
+            .expect("reload group")
+            .unwrap();
         // The last messages should not fail
         for application_message in application_messages.iter().skip(max_epochs / 2) {
-            let mut bob_group = MlsGroup::load(provider.storage(), bob_group.group_id())
-                .expect("reload group")
-                .unwrap();
             let bob_processed_message = bob_group
                 .process_message(provider, application_message.clone())
                 .expect("An unexpected error occurred.");


### PR DESCRIPTION
## Summary

I was trying to reproduce the issue we've been seeing with OpenMLS where the `max_past_epochs` flag was set to 3, but messages from even 1 previous epoch were failing with an `AeadError`.

Your existing test for past epoch secrets passes so long as there is an in-memory group instance that is being updated. But if you attempt to load the group from storage before processing the message the `MessageSecretsStore` has no `past_tree_epochs` available and fails to decrypt with an `AeadError`.

I'm assuming we just need to write the `MessageSecrets` to the storage provider after they have been updated, which I did in the last commit in this branch and the test starts passing again. If you remove the changes to `process.rs` you will see the test failing with an `AeadError`