### PR TITLE
Make some PrivateMessageIn fields public

### DIFF
--- a/openmls/src/framing/private_message_in.rs
+++ b/openmls/src/framing/private_message_in.rs
@@ -200,17 +200,17 @@ impl PrivateMessageIn {
     }
 
     /// Get the `group_id` in the `PrivateMessage`.
-    pub(crate) fn group_id(&self) -> &GroupId {
+    pub fn group_id(&self) -> &GroupId {
         &self.group_id
     }
 
     /// Get the `epoch` in the `PrivateMessage`.
-    pub(crate) fn epoch(&self) -> GroupEpoch {
+    pub fn epoch(&self) -> GroupEpoch {
         self.epoch
     }
 
     /// Get the `content_type` in the `PrivateMessage`.
-    pub(crate) fn content_type(&self) -> ContentType {
+    pub fn content_type(&self) -> ContentType {
         self.content_type
     }
 


### PR DESCRIPTION
## tl;dr

We want to access the `content_type` field from libxmtp, so we are making that (and a few other safe fields) public.