### PR TITLE
Bincode fixes 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake ~/code/environments#rust-stable

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ fuzz/artifacts
 
 # AI
 .cursor/
+.envrc
+.direnv/**
+**/.direnv/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64",
- "bitflags 2.11.0",
+ "bitflags",
  "brotli",
  "bytes",
  "bytestring",
@@ -466,12 +466,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1274,21 +1268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluvio-wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b768c170dc045fa587a8f948c91f9bcfb87f774930477c6215addf54317f137f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,21 +1295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,17 +1309,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1398,7 +1351,6 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2023,18 +1975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2710,7 +2650,6 @@ dependencies = [
  "clap",
  "criterion",
  "flate2",
- "fluvio-wasm-timer",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "hex",
@@ -2738,6 +2677,7 @@ dependencies = [
  "tls_codec",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "web-time",
  "zeroize",
 ]
 
@@ -2913,37 +2853,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3016,12 +2931,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -3220,7 +3129,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -3425,20 +3334,11 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3644,7 +3544,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3679,7 +3579,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3817,7 +3717,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4091,7 +3991,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4286,7 +4186,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
@@ -4503,7 +4403,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -4872,7 +4772,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4895,6 +4795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -5271,7 +5172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -39,7 +39,7 @@ itertools = { version = "0.14", optional = true }
 wasm-bindgen-test = { version = "0.3.50", optional = true }
 getrandom = { version = "0.3.4", optional = true }
 getrandom_old = { package = "getrandom", version = "0.2.15", optional = true }
-fluvio-wasm-timer = { version = "0.2.5", optional = true }
+web-time = { version = "1.1", optional = true, features = ["serde"] }
 once_cell = { version = "1.19.0", optional = true }
 zeroize = "1.8.1"
 serde_bytes = "0.11.17"
@@ -70,7 +70,7 @@ crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
     "dep:getrandom",
-    "dep:fluvio-wasm-timer",
+    "dep:web-time",
 
     # enable randomness source
     "getrandom/wasm_js",

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -77,10 +77,7 @@ pub mod errors;
 /// | 0xDADA           | GREASE                   | Y | RFC XXXX |
 /// | 0xEAEA           | GREASE                   | Y | RFC XXXX |
 /// | 0xF000  - 0xFFFF | Reserved for Private Use | - | RFC XXXX |
-// Variant order is part of the serde wire format for non-self-describing
-// serializers like bincode. Do not reorder existing variants; append new
-// variants at the end of the enum.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u16)]
 pub enum CredentialType {
     /// A [`BasicCredential`]
@@ -89,12 +86,114 @@ pub enum CredentialType {
     X509 = 2,
     /// Another type of credential that is not in the MLS protocol spec.
     Other(u16),
-
-    // --- Variants appended after openmls-0.7.x ---
-    // New variants MUST be added below this line to preserve the serde wire
-    // format with older persisted data.
     /// A GREASE credential type for ensuring extensibility.
     Grease(u16),
+}
+
+// Manual serde impls with explicit variant indices. The variant index is the
+// bincode/postcard wire format for this enum; the variant *name* is the JSON
+// wire format. Both must remain stable across versions. Indices are listed in
+// the constant below — new variants get a fresh, never-reused index appended
+// at the end; existing variants never change index.
+const CREDENTIAL_TYPE_VARIANTS: &[&str] = &["Basic", "X509", "Other", "Grease"];
+
+impl Serialize for CredentialType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Basic => serializer.serialize_unit_variant("CredentialType", 0, "Basic"),
+            Self::X509 => serializer.serialize_unit_variant("CredentialType", 1, "X509"),
+            Self::Other(v) => serializer.serialize_newtype_variant("CredentialType", 2, "Other", v),
+            Self::Grease(v) => {
+                serializer.serialize_newtype_variant("CredentialType", 3, "Grease", v)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CredentialType {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum(
+            "CredentialType",
+            CREDENTIAL_TYPE_VARIANTS,
+            CredentialTypeVisitor,
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CredentialTypeId {
+    Basic,
+    X509,
+    Other,
+    Grease,
+}
+
+impl<'de> Deserialize<'de> for CredentialTypeId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = CredentialTypeId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("CredentialType variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(CredentialTypeId::Basic),
+                    1 => Ok(CredentialTypeId::X509),
+                    2 => Ok(CredentialTypeId::Other),
+                    3 => Ok(CredentialTypeId::Grease),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"variant index 0..=3",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "Basic" => Ok(CredentialTypeId::Basic),
+                    "X509" => Ok(CredentialTypeId::X509),
+                    "Other" => Ok(CredentialTypeId::Other),
+                    "Grease" => Ok(CredentialTypeId::Grease),
+                    other => Err(E::unknown_variant(other, CREDENTIAL_TYPE_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct CredentialTypeVisitor;
+
+impl<'de> serde::de::Visitor<'de> for CredentialTypeVisitor {
+    type Value = CredentialType;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum CredentialType")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<CredentialTypeId>()?;
+        match variant {
+            CredentialTypeId::Basic => {
+                access.unit_variant()?;
+                Ok(CredentialType::Basic)
+            }
+            CredentialTypeId::X509 => {
+                access.unit_variant()?;
+                Ok(CredentialType::X509)
+            }
+            CredentialTypeId::Other => Ok(CredentialType::Other(access.newtype_variant()?)),
+            CredentialTypeId::Grease => Ok(CredentialType::Grease(access.newtype_variant()?)),
+        }
+    }
 }
 
 impl CredentialType {

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -77,6 +77,9 @@ pub mod errors;
 /// | 0xDADA           | GREASE                   | Y | RFC XXXX |
 /// | 0xEAEA           | GREASE                   | Y | RFC XXXX |
 /// | 0xF000  - 0xFFFF | Reserved for Private Use | - | RFC XXXX |
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum CredentialType {
@@ -84,10 +87,14 @@ pub enum CredentialType {
     Basic = 1,
     /// An X.509 [`Certificate`]
     X509 = 2,
-    /// A GREASE credential type for ensuring extensibility.
-    Grease(u16),
     /// Another type of credential that is not in the MLS protocol spec.
     Other(u16),
+
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    /// A GREASE credential type for ensuring extensibility.
+    Grease(u16),
 }
 
 impl CredentialType {

--- a/openmls/src/credentials/tests.rs
+++ b/openmls/src/credentials/tests.rs
@@ -49,3 +49,30 @@ fn that_unknown_credential_types_are_de_serialized_correctly() {
         assert_eq!(test, got_serialized);
     }
 }
+
+/// Locks the `(variant_index, variant_name)` pair that the manual `Serialize`
+/// impl for [`CredentialType`] emits for each variant. These values are the
+/// bincode/postcard wire encoding of the enum tag and must not change without
+/// a deliberate, versioned migration of every existing persisted group.
+///
+/// When adding a new variant, append a new `check(...)` line with a fresh
+/// `variant_index` — never reuse or renumber the existing entries.
+#[test]
+fn credential_type_variant_indices() {
+    use crate::utils::variant_index_probe::probe;
+
+    fn check(value: CredentialType, expected_index: u32, expected_name: &'static str) {
+        let (idx, name) =
+            probe(&value).expect("CredentialType Serialize should call serialize_*_variant");
+        assert_eq!(
+            (idx, name),
+            (expected_index, expected_name),
+            "CredentialType::{expected_name} drifted from index {expected_index}",
+        );
+    }
+
+    check(CredentialType::Basic, 0, "Basic");
+    check(CredentialType::X509, 1, "X509");
+    check(CredentialType::Other(0), 2, "Other");
+    check(CredentialType::Grease(0), 3, "Grease");
+}

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -88,6 +88,9 @@ mod tests;
 /// | 0xff00  - 0xffff | Reserved for Private Use | N/A        | N/A         | RFC XXXX  |
 ///
 /// Note: OpenMLS does not provide a `Reserved` variant in [ExtensionType].
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum ExtensionType {
     /// The application id extension allows applications to add an explicit,
@@ -118,15 +121,18 @@ pub enum ExtensionType {
     /// This can only be set on creation of the group.
     ImmutableMetadata,
 
-    #[cfg(feature = "extensions-draft-08")]
-    /// AppDataDictionary extension
-    AppDataDictionary,
+    /// A currently unknown extension type.
+    Unknown(u16),
 
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
     /// A GREASE extension type for ensuring extensibility.
     Grease(u16),
 
-    /// A currently unknown extension type.
-    Unknown(u16),
+    #[cfg(feature = "extensions-draft-08")]
+    /// AppDataDictionary extension
+    AppDataDictionary,
 }
 
 impl ExtensionType {
@@ -321,6 +327,9 @@ impl ExtensionType {
 ///     opaque extension_data<V>;
 /// } Extension;
 /// ```
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Extension {
     /// An [`ApplicationIdExtension`]
@@ -338,10 +347,6 @@ pub enum Extension {
     /// An [`ExternalSendersExtension`]
     ExternalSenders(ExternalSendersExtension),
 
-    /// An [`AppDataDictionaryExtension`]
-    #[cfg(feature = "extensions-draft-08")]
-    AppDataDictionary(AppDataDictionaryExtension),
-
     /// A [`LastResortExtension`]
     LastResort(LastResortExtension),
 
@@ -350,6 +355,13 @@ pub enum Extension {
 
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
+
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    /// An [`AppDataDictionaryExtension`]
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataDictionary(AppDataDictionaryExtension),
 }
 
 /// A unknown/unparsed extension represented by raw bytes.

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -142,6 +142,7 @@ const EXTENSION_TYPE_VARIANTS: &[&str] = &[
     "ExternalPub",
     "ExternalSenders",
     "LastResort",
+    "ImmutableMetadata",
     "Unknown",
     "Grease",
     #[cfg(feature = "extensions-draft-08")]
@@ -167,15 +168,18 @@ impl Serialize for ExtensionType {
                 serializer.serialize_unit_variant("ExtensionType", 4, "ExternalSenders")
             }
             Self::LastResort => serializer.serialize_unit_variant("ExtensionType", 5, "LastResort"),
+            Self::ImmutableMetadata => {
+                serializer.serialize_unit_variant("ExtensionType", 6, "ImmutableMetadata")
+            }
             Self::Unknown(v) => {
-                serializer.serialize_newtype_variant("ExtensionType", 6, "Unknown", v)
+                serializer.serialize_newtype_variant("ExtensionType", 7, "Unknown", v)
             }
             Self::Grease(v) => {
-                serializer.serialize_newtype_variant("ExtensionType", 7, "Grease", v)
+                serializer.serialize_newtype_variant("ExtensionType", 8, "Grease", v)
             }
             #[cfg(feature = "extensions-draft-08")]
             Self::AppDataDictionary => {
-                serializer.serialize_unit_variant("ExtensionType", 8, "AppDataDictionary")
+                serializer.serialize_unit_variant("ExtensionType", 9, "AppDataDictionary")
             }
         }
     }
@@ -199,6 +203,7 @@ enum ExtensionTypeId {
     ExternalPub,
     ExternalSenders,
     LastResort,
+    ImmutableMetadata,
     Unknown,
     Grease,
     #[cfg(feature = "extensions-draft-08")]
@@ -223,10 +228,11 @@ impl<'de> Deserialize<'de> for ExtensionTypeId {
                     3 => Ok(ExtensionTypeId::ExternalPub),
                     4 => Ok(ExtensionTypeId::ExternalSenders),
                     5 => Ok(ExtensionTypeId::LastResort),
-                    6 => Ok(ExtensionTypeId::Unknown),
-                    7 => Ok(ExtensionTypeId::Grease),
+                    6 => Ok(ExtensionTypeId::ImmutableMetadata),
+                    7 => Ok(ExtensionTypeId::Unknown),
+                    8 => Ok(ExtensionTypeId::Grease),
                     #[cfg(feature = "extensions-draft-08")]
-                    8 => Ok(ExtensionTypeId::AppDataDictionary),
+                    9 => Ok(ExtensionTypeId::AppDataDictionary),
                     other => Err(E::invalid_value(
                         serde::de::Unexpected::Unsigned(other),
                         &"valid ExtensionType variant index",
@@ -242,6 +248,7 @@ impl<'de> Deserialize<'de> for ExtensionTypeId {
                     "ExternalPub" => Ok(ExtensionTypeId::ExternalPub),
                     "ExternalSenders" => Ok(ExtensionTypeId::ExternalSenders),
                     "LastResort" => Ok(ExtensionTypeId::LastResort),
+                    "ImmutableMetadata" => Ok(ExtensionTypeId::ImmutableMetadata),
                     "Unknown" => Ok(ExtensionTypeId::Unknown),
                     "Grease" => Ok(ExtensionTypeId::Grease),
                     #[cfg(feature = "extensions-draft-08")]
@@ -294,6 +301,10 @@ impl<'de> serde::de::Visitor<'de> for ExtensionTypeVisitor {
             ExtensionTypeId::LastResort => {
                 access.unit_variant()?;
                 Ok(ExtensionType::LastResort)
+            }
+            ExtensionTypeId::ImmutableMetadata => {
+                access.unit_variant()?;
+                Ok(ExtensionType::ImmutableMetadata)
             }
             ExtensionTypeId::Unknown => Ok(ExtensionType::Unknown(access.newtype_variant()?)),
             ExtensionTypeId::Grease => Ok(ExtensionType::Grease(access.newtype_variant()?)),
@@ -538,6 +549,7 @@ const EXTENSION_VARIANTS: &[&str] = &[
     "ExternalPub",
     "ExternalSenders",
     "LastResort",
+    "ImmutableMetadata",
     "Unknown",
     #[cfg(feature = "extensions-draft-08")]
     "AppDataDictionary",
@@ -565,15 +577,18 @@ impl Serialize for Extension {
             Self::LastResort(e) => {
                 serializer.serialize_newtype_variant("Extension", 5, "LastResort", e)
             }
+            Self::ImmutableMetadata(e) => {
+                serializer.serialize_newtype_variant("Extension", 6, "ImmutableMetadata", e)
+            }
             Self::Unknown(t, data) => {
-                let mut tv = serializer.serialize_tuple_variant("Extension", 6, "Unknown", 2)?;
+                let mut tv = serializer.serialize_tuple_variant("Extension", 7, "Unknown", 2)?;
                 tv.serialize_field(t)?;
                 tv.serialize_field(data)?;
                 tv.end()
             }
             #[cfg(feature = "extensions-draft-08")]
             Self::AppDataDictionary(e) => {
-                serializer.serialize_newtype_variant("Extension", 7, "AppDataDictionary", e)
+                serializer.serialize_newtype_variant("Extension", 8, "AppDataDictionary", e)
             }
         }
     }
@@ -593,6 +608,7 @@ enum ExtensionId {
     ExternalPub,
     ExternalSenders,
     LastResort,
+    ImmutableMetadata,
     Unknown,
     #[cfg(feature = "extensions-draft-08")]
     AppDataDictionary,
@@ -616,9 +632,10 @@ impl<'de> Deserialize<'de> for ExtensionId {
                     3 => Ok(ExtensionId::ExternalPub),
                     4 => Ok(ExtensionId::ExternalSenders),
                     5 => Ok(ExtensionId::LastResort),
-                    6 => Ok(ExtensionId::Unknown),
+                    6 => Ok(ExtensionId::ImmutableMetadata),
+                    7 => Ok(ExtensionId::Unknown),
                     #[cfg(feature = "extensions-draft-08")]
-                    7 => Ok(ExtensionId::AppDataDictionary),
+                    8 => Ok(ExtensionId::AppDataDictionary),
                     other => Err(E::invalid_value(
                         serde::de::Unexpected::Unsigned(other),
                         &"valid Extension variant index",
@@ -634,6 +651,7 @@ impl<'de> Deserialize<'de> for ExtensionId {
                     "ExternalPub" => Ok(ExtensionId::ExternalPub),
                     "ExternalSenders" => Ok(ExtensionId::ExternalSenders),
                     "LastResort" => Ok(ExtensionId::LastResort),
+                    "ImmutableMetadata" => Ok(ExtensionId::ImmutableMetadata),
                     "Unknown" => Ok(ExtensionId::Unknown),
                     #[cfg(feature = "extensions-draft-08")]
                     "AppDataDictionary" => Ok(ExtensionId::AppDataDictionary),
@@ -672,6 +690,9 @@ impl<'de> serde::de::Visitor<'de> for ExtensionVisitor {
                 Ok(Extension::ExternalSenders(access.newtype_variant()?))
             }
             ExtensionId::LastResort => Ok(Extension::LastResort(access.newtype_variant()?)),
+            ExtensionId::ImmutableMetadata => {
+                Ok(Extension::ImmutableMetadata(access.newtype_variant()?))
+            }
             ExtensionId::Unknown => {
                 struct UnknownPayload;
                 impl<'de> serde::de::Visitor<'de> for UnknownPayload {

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -88,10 +88,7 @@ mod tests;
 /// | 0xff00  - 0xffff | Reserved for Private Use | N/A        | N/A         | RFC XXXX  |
 ///
 /// Note: OpenMLS does not provide a `Reserved` variant in [ExtensionType].
-// Variant order is part of the serde wire format for non-self-describing
-// serializers like bincode. Do not reorder existing variants; append new
-// variants at the end of the enum.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum ExtensionType {
     /// The application id extension allows applications to add an explicit,
     /// application-defined identifier to a KeyPackage.
@@ -124,15 +121,189 @@ pub enum ExtensionType {
     /// A currently unknown extension type.
     Unknown(u16),
 
-    // --- Variants appended after openmls-0.7.x ---
-    // New variants MUST be added below this line to preserve the serde wire
-    // format with older persisted data.
     /// A GREASE extension type for ensuring extensibility.
     Grease(u16),
 
     #[cfg(feature = "extensions-draft-08")]
     /// AppDataDictionary extension
     AppDataDictionary,
+}
+
+// Manual serde impls with explicit variant indices. See the comment on
+// `CredentialType` in `credentials/mod.rs` for the rationale: indices are the
+// bincode wire format and must remain stable across versions. Variant 8
+// (`AppDataDictionary`) only exists when the `extensions-draft-08` feature is
+// enabled, but its index is reserved unconditionally so toggling the feature
+// does not shift the indices of any other variant.
+const EXTENSION_TYPE_VARIANTS: &[&str] = &[
+    "ApplicationId",
+    "RatchetTree",
+    "RequiredCapabilities",
+    "ExternalPub",
+    "ExternalSenders",
+    "LastResort",
+    "Unknown",
+    "Grease",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppDataDictionary",
+];
+
+impl Serialize for ExtensionType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::ApplicationId => {
+                serializer.serialize_unit_variant("ExtensionType", 0, "ApplicationId")
+            }
+            Self::RatchetTree => {
+                serializer.serialize_unit_variant("ExtensionType", 1, "RatchetTree")
+            }
+            Self::RequiredCapabilities => {
+                serializer.serialize_unit_variant("ExtensionType", 2, "RequiredCapabilities")
+            }
+            Self::ExternalPub => {
+                serializer.serialize_unit_variant("ExtensionType", 3, "ExternalPub")
+            }
+            Self::ExternalSenders => {
+                serializer.serialize_unit_variant("ExtensionType", 4, "ExternalSenders")
+            }
+            Self::LastResort => serializer.serialize_unit_variant("ExtensionType", 5, "LastResort"),
+            Self::Unknown(v) => {
+                serializer.serialize_newtype_variant("ExtensionType", 6, "Unknown", v)
+            }
+            Self::Grease(v) => {
+                serializer.serialize_newtype_variant("ExtensionType", 7, "Grease", v)
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppDataDictionary => {
+                serializer.serialize_unit_variant("ExtensionType", 8, "AppDataDictionary")
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtensionType {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum(
+            "ExtensionType",
+            EXTENSION_TYPE_VARIANTS,
+            ExtensionTypeVisitor,
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ExtensionTypeId {
+    ApplicationId,
+    RatchetTree,
+    RequiredCapabilities,
+    ExternalPub,
+    ExternalSenders,
+    LastResort,
+    Unknown,
+    Grease,
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataDictionary,
+}
+
+impl<'de> Deserialize<'de> for ExtensionTypeId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = ExtensionTypeId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("ExtensionType variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(ExtensionTypeId::ApplicationId),
+                    1 => Ok(ExtensionTypeId::RatchetTree),
+                    2 => Ok(ExtensionTypeId::RequiredCapabilities),
+                    3 => Ok(ExtensionTypeId::ExternalPub),
+                    4 => Ok(ExtensionTypeId::ExternalSenders),
+                    5 => Ok(ExtensionTypeId::LastResort),
+                    6 => Ok(ExtensionTypeId::Unknown),
+                    7 => Ok(ExtensionTypeId::Grease),
+                    #[cfg(feature = "extensions-draft-08")]
+                    8 => Ok(ExtensionTypeId::AppDataDictionary),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"valid ExtensionType variant index",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "ApplicationId" => Ok(ExtensionTypeId::ApplicationId),
+                    "RatchetTree" => Ok(ExtensionTypeId::RatchetTree),
+                    "RequiredCapabilities" => Ok(ExtensionTypeId::RequiredCapabilities),
+                    "ExternalPub" => Ok(ExtensionTypeId::ExternalPub),
+                    "ExternalSenders" => Ok(ExtensionTypeId::ExternalSenders),
+                    "LastResort" => Ok(ExtensionTypeId::LastResort),
+                    "Unknown" => Ok(ExtensionTypeId::Unknown),
+                    "Grease" => Ok(ExtensionTypeId::Grease),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppDataDictionary" => Ok(ExtensionTypeId::AppDataDictionary),
+                    other => Err(E::unknown_variant(other, EXTENSION_TYPE_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct ExtensionTypeVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ExtensionTypeVisitor {
+    type Value = ExtensionType;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum ExtensionType")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<ExtensionTypeId>()?;
+        match variant {
+            ExtensionTypeId::ApplicationId => {
+                access.unit_variant()?;
+                Ok(ExtensionType::ApplicationId)
+            }
+            ExtensionTypeId::RatchetTree => {
+                access.unit_variant()?;
+                Ok(ExtensionType::RatchetTree)
+            }
+            ExtensionTypeId::RequiredCapabilities => {
+                access.unit_variant()?;
+                Ok(ExtensionType::RequiredCapabilities)
+            }
+            ExtensionTypeId::ExternalPub => {
+                access.unit_variant()?;
+                Ok(ExtensionType::ExternalPub)
+            }
+            ExtensionTypeId::ExternalSenders => {
+                access.unit_variant()?;
+                Ok(ExtensionType::ExternalSenders)
+            }
+            ExtensionTypeId::LastResort => {
+                access.unit_variant()?;
+                Ok(ExtensionType::LastResort)
+            }
+            ExtensionTypeId::Unknown => Ok(ExtensionType::Unknown(access.newtype_variant()?)),
+            ExtensionTypeId::Grease => Ok(ExtensionType::Grease(access.newtype_variant()?)),
+            #[cfg(feature = "extensions-draft-08")]
+            ExtensionTypeId::AppDataDictionary => {
+                access.unit_variant()?;
+                Ok(ExtensionType::AppDataDictionary)
+            }
+        }
+    }
 }
 
 impl ExtensionType {
@@ -327,10 +498,7 @@ impl ExtensionType {
 ///     opaque extension_data<V>;
 /// } Extension;
 /// ```
-// Variant order is part of the serde wire format for non-self-describing
-// serializers like bincode. Do not reorder existing variants; append new
-// variants at the end of the enum.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Extension {
     /// An [`ApplicationIdExtension`]
     ApplicationId(ApplicationIdExtension),
@@ -356,12 +524,184 @@ pub enum Extension {
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
 
-    // --- Variants appended after openmls-0.7.x ---
-    // New variants MUST be added below this line to preserve the serde wire
-    // format with older persisted data.
     /// An [`AppDataDictionaryExtension`]
     #[cfg(feature = "extensions-draft-08")]
     AppDataDictionary(AppDataDictionaryExtension),
+}
+
+// Manual serde impls with explicit variant indices. See the comment on
+// `CredentialType` in `credentials/mod.rs` for the rationale.
+const EXTENSION_VARIANTS: &[&str] = &[
+    "ApplicationId",
+    "RatchetTree",
+    "RequiredCapabilities",
+    "ExternalPub",
+    "ExternalSenders",
+    "LastResort",
+    "Unknown",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppDataDictionary",
+];
+
+impl Serialize for Extension {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeTupleVariant;
+        match self {
+            Self::ApplicationId(e) => {
+                serializer.serialize_newtype_variant("Extension", 0, "ApplicationId", e)
+            }
+            Self::RatchetTree(e) => {
+                serializer.serialize_newtype_variant("Extension", 1, "RatchetTree", e)
+            }
+            Self::RequiredCapabilities(e) => {
+                serializer.serialize_newtype_variant("Extension", 2, "RequiredCapabilities", e)
+            }
+            Self::ExternalPub(e) => {
+                serializer.serialize_newtype_variant("Extension", 3, "ExternalPub", e)
+            }
+            Self::ExternalSenders(e) => {
+                serializer.serialize_newtype_variant("Extension", 4, "ExternalSenders", e)
+            }
+            Self::LastResort(e) => {
+                serializer.serialize_newtype_variant("Extension", 5, "LastResort", e)
+            }
+            Self::Unknown(t, data) => {
+                let mut tv = serializer.serialize_tuple_variant("Extension", 6, "Unknown", 2)?;
+                tv.serialize_field(t)?;
+                tv.serialize_field(data)?;
+                tv.end()
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppDataDictionary(e) => {
+                serializer.serialize_newtype_variant("Extension", 7, "AppDataDictionary", e)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Extension {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum("Extension", EXTENSION_VARIANTS, ExtensionVisitor)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ExtensionId {
+    ApplicationId,
+    RatchetTree,
+    RequiredCapabilities,
+    ExternalPub,
+    ExternalSenders,
+    LastResort,
+    Unknown,
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataDictionary,
+}
+
+impl<'de> Deserialize<'de> for ExtensionId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = ExtensionId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("Extension variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(ExtensionId::ApplicationId),
+                    1 => Ok(ExtensionId::RatchetTree),
+                    2 => Ok(ExtensionId::RequiredCapabilities),
+                    3 => Ok(ExtensionId::ExternalPub),
+                    4 => Ok(ExtensionId::ExternalSenders),
+                    5 => Ok(ExtensionId::LastResort),
+                    6 => Ok(ExtensionId::Unknown),
+                    #[cfg(feature = "extensions-draft-08")]
+                    7 => Ok(ExtensionId::AppDataDictionary),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"valid Extension variant index",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "ApplicationId" => Ok(ExtensionId::ApplicationId),
+                    "RatchetTree" => Ok(ExtensionId::RatchetTree),
+                    "RequiredCapabilities" => Ok(ExtensionId::RequiredCapabilities),
+                    "ExternalPub" => Ok(ExtensionId::ExternalPub),
+                    "ExternalSenders" => Ok(ExtensionId::ExternalSenders),
+                    "LastResort" => Ok(ExtensionId::LastResort),
+                    "Unknown" => Ok(ExtensionId::Unknown),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppDataDictionary" => Ok(ExtensionId::AppDataDictionary),
+                    other => Err(E::unknown_variant(other, EXTENSION_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct ExtensionVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ExtensionVisitor {
+    type Value = Extension;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum Extension")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<ExtensionId>()?;
+        match variant {
+            ExtensionId::ApplicationId => Ok(Extension::ApplicationId(access.newtype_variant()?)),
+            ExtensionId::RatchetTree => Ok(Extension::RatchetTree(access.newtype_variant()?)),
+            ExtensionId::RequiredCapabilities => {
+                Ok(Extension::RequiredCapabilities(access.newtype_variant()?))
+            }
+            ExtensionId::ExternalPub => Ok(Extension::ExternalPub(access.newtype_variant()?)),
+            ExtensionId::ExternalSenders => {
+                Ok(Extension::ExternalSenders(access.newtype_variant()?))
+            }
+            ExtensionId::LastResort => Ok(Extension::LastResort(access.newtype_variant()?)),
+            ExtensionId::Unknown => {
+                struct UnknownPayload;
+                impl<'de> serde::de::Visitor<'de> for UnknownPayload {
+                    type Value = (u16, UnknownExtension);
+                    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                        f.write_str("tuple (u16, UnknownExtension)")
+                    }
+                    fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                        self,
+                        mut seq: A,
+                    ) -> Result<Self::Value, A::Error> {
+                        use serde::de::Error;
+                        let t: u16 = seq
+                            .next_element()?
+                            .ok_or_else(|| Error::invalid_length(0, &self))?;
+                        let data: UnknownExtension = seq
+                            .next_element()?
+                            .ok_or_else(|| Error::invalid_length(1, &self))?;
+                        Ok((t, data))
+                    }
+                }
+                let (t, data) = access.tuple_variant(2, UnknownPayload)?;
+                Ok(Extension::Unknown(t, data))
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            ExtensionId::AppDataDictionary => {
+                Ok(Extension::AppDataDictionary(access.newtype_variant()?))
+            }
+        }
+    }
 }
 
 /// A unknown/unparsed extension represented by raw bytes.

--- a/openmls/src/extensions/tests.rs
+++ b/openmls/src/extensions/tests.rs
@@ -503,10 +503,11 @@ fn extension_type_variant_indices() {
     check(ExtensionType::ExternalPub, 3, "ExternalPub");
     check(ExtensionType::ExternalSenders, 4, "ExternalSenders");
     check(ExtensionType::LastResort, 5, "LastResort");
-    check(ExtensionType::Unknown(0), 6, "Unknown");
-    check(ExtensionType::Grease(0), 7, "Grease");
+    check(ExtensionType::ImmutableMetadata, 6, "ImmutableMetadata");
+    check(ExtensionType::Unknown(0), 7, "Unknown");
+    check(ExtensionType::Grease(0), 8, "Grease");
     #[cfg(feature = "extensions-draft-08")]
-    check(ExtensionType::AppDataDictionary, 8, "AppDataDictionary");
+    check(ExtensionType::AppDataDictionary, 9, "AppDataDictionary");
 }
 
 /// Locks the `(variant_index, variant_name)` pair for each [`Extension`]
@@ -560,14 +561,19 @@ fn extension_variant_indices() {
         "LastResort",
     );
     check(
-        Extension::Unknown(0, UnknownExtension(vec![])),
+        Extension::ImmutableMetadata(crate::extensions::Metadata::new(vec![])),
         6,
+        "ImmutableMetadata",
+    );
+    check(
+        Extension::Unknown(0, UnknownExtension(vec![])),
+        7,
         "Unknown",
     );
     #[cfg(feature = "extensions-draft-08")]
     check(
         Extension::AppDataDictionary(AppDataDictionaryExtension::new(AppDataDictionary::new())),
-        7,
+        8,
         "AppDataDictionary",
     );
 }

--- a/openmls/src/extensions/tests.rs
+++ b/openmls/src/extensions/tests.rs
@@ -471,3 +471,103 @@ fn app_data_dictionary_extension() {
     // check the dictionary
     assert_eq!(&dictionary, extension.dictionary());
 }
+
+/// Locks the `(variant_index, variant_name)` pair that the manual `Serialize`
+/// impl for [`ExtensionType`] emits for each variant. These values are the
+/// bincode/postcard wire encoding of the enum tag and must not change without
+/// a deliberate, versioned migration of every existing persisted group.
+///
+/// When adding a new variant, append a new `check(...)` line with a fresh
+/// `variant_index` — never reuse or renumber the existing entries.
+#[test]
+fn extension_type_variant_indices() {
+    use crate::utils::variant_index_probe::probe;
+
+    fn check(value: ExtensionType, expected_index: u32, expected_name: &'static str) {
+        let (idx, name) =
+            probe(&value).expect("ExtensionType Serialize should call serialize_*_variant");
+        assert_eq!(
+            (idx, name),
+            (expected_index, expected_name),
+            "ExtensionType::{expected_name} drifted from index {expected_index}",
+        );
+    }
+
+    check(ExtensionType::ApplicationId, 0, "ApplicationId");
+    check(ExtensionType::RatchetTree, 1, "RatchetTree");
+    check(
+        ExtensionType::RequiredCapabilities,
+        2,
+        "RequiredCapabilities",
+    );
+    check(ExtensionType::ExternalPub, 3, "ExternalPub");
+    check(ExtensionType::ExternalSenders, 4, "ExternalSenders");
+    check(ExtensionType::LastResort, 5, "LastResort");
+    check(ExtensionType::Unknown(0), 6, "Unknown");
+    check(ExtensionType::Grease(0), 7, "Grease");
+    #[cfg(feature = "extensions-draft-08")]
+    check(ExtensionType::AppDataDictionary, 8, "AppDataDictionary");
+}
+
+/// Locks the `(variant_index, variant_name)` pair for each [`Extension`]
+/// variant. See [`extension_type_variant_indices`] for the rationale and
+/// growth discipline.
+///
+/// The payloads of newtype/tuple variants are never serialized by the probe
+/// — they are constructed only to satisfy Rust's type system at the call
+/// site. Using minimal/empty payloads keeps this test independent of any
+/// other types.
+#[test]
+fn extension_variant_indices() {
+    use crate::utils::variant_index_probe::probe;
+
+    fn check(value: Extension, expected_index: u32, expected_name: &'static str) {
+        let (idx, name) =
+            probe(&value).expect("Extension Serialize should call serialize_*_variant");
+        assert_eq!(
+            (idx, name),
+            (expected_index, expected_name),
+            "Extension::{expected_name} drifted from index {expected_index}",
+        );
+    }
+
+    check(
+        Extension::ApplicationId(ApplicationIdExtension::new(&[])),
+        0,
+        "ApplicationId",
+    );
+    check(
+        Extension::RatchetTree(RatchetTreeExtension::new(
+            RatchetTreeIn::from_nodes(vec![]).into(),
+        )),
+        1,
+        "RatchetTree",
+    );
+    check(
+        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::default()),
+        2,
+        "RequiredCapabilities",
+    );
+    check(
+        Extension::ExternalPub(ExternalPubExtension::new(HpkePublicKey::new(vec![]))),
+        3,
+        "ExternalPub",
+    );
+    check(Extension::ExternalSenders(vec![]), 4, "ExternalSenders");
+    check(
+        Extension::LastResort(LastResortExtension::new()),
+        5,
+        "LastResort",
+    );
+    check(
+        Extension::Unknown(0, UnknownExtension(vec![])),
+        6,
+        "Unknown",
+    );
+    #[cfg(feature = "extensions-draft-08")]
+    check(
+        Extension::AppDataDictionary(AppDataDictionaryExtension::new(AppDataDictionary::new())),
+        7,
+        "AppDataDictionary",
+    );
+}

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -27,6 +27,11 @@
 //!     .build();
 //! ```
 
+#[cfg(target_arch = "wasm32")]
+use web_time::SystemTime;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::SystemTime;
+
 use super::*;
 use crate::{
     extensions::Extensions,
@@ -119,7 +124,7 @@ pub struct PastEpochDeletion {
 /// A duration or timestamp before which to delete past epoch secrets.
 pub(crate) enum PastEpochDeletionTimeConfig {
     OlderThanDuration(std::time::Duration),
-    BeforeTimestamp(std::time::SystemTime),
+    BeforeTimestamp(SystemTime),
     DeleteAllWithoutTimestamp,
 }
 
@@ -133,7 +138,7 @@ impl PastEpochDeletion {
     }
 
     /// Delete all past epoch secrets before a provided timestamp.
-    pub fn before_timestamp(timestamp: std::time::SystemTime) -> Self {
+    pub fn before_timestamp(timestamp: SystemTime) -> Self {
         Self {
             config: Some(PastEpochDeletionTimeConfig::BeforeTimestamp(timestamp)),
             max_past_epochs: None,

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -76,11 +76,16 @@ impl Serialize for PastEpochDeletionPolicy {
     where
         S: serde::Serializer,
     {
-        let usize = match self {
-            Self::MaxEpochs(epochs) => *epochs,
-            Self::KeepAll => usize::MAX,
+        // Wire encoding is always `u64` (never platform-dependent `usize`) so
+        // bytes written on a 64-bit host are still readable on `wasm32` and
+        // vice versa. `KeepAll` is encoded as `u64::MAX` rather than
+        // `usize::MAX as u64`, because `usize::MAX` differs between platforms
+        // (`u32::MAX` on `wasm32`, `u64::MAX` on 64-bit).
+        let value: u64 = match self {
+            Self::MaxEpochs(epochs) => *epochs as u64,
+            Self::KeepAll => u64::MAX,
         };
-        serializer.serialize_u64(usize as u64)
+        serializer.serialize_u64(value)
     }
 }
 
@@ -89,11 +94,11 @@ impl<'de> Deserialize<'de> for PastEpochDeletionPolicy {
     where
         D: serde::Deserializer<'de>,
     {
-        let epochs = u64::deserialize(deserializer)?;
-        let epochs = usize::try_from(epochs).map_err(serde::de::Error::custom)?;
-        if epochs == usize::MAX {
+        let value = u64::deserialize(deserializer)?;
+        if value == u64::MAX {
             Ok(Self::KeepAll)
         } else {
+            let epochs = usize::try_from(value).map_err(serde::de::Error::custom)?;
             Ok(Self::MaxEpochs(epochs))
         }
     }
@@ -190,6 +195,7 @@ pub struct MlsGroupJoinConfig {
     /// Application are always encrypted regardless.
     pub(crate) wire_format_policy: WireFormatPolicy,
     /// Size of padding in bytes
+    #[serde(with = "crate::utils::usize_as_u64")]
     pub(crate) padding_size: usize,
     /// Maximum number of past epochs for which application messages
     /// can be decrypted. The default is 0.
@@ -197,6 +203,7 @@ pub struct MlsGroupJoinConfig {
     // alias for backwards compatibility after renaming field
     pub(crate) past_epoch_deletion_policy: PastEpochDeletionPolicy,
     /// Number of resumption secrets to keep
+    #[serde(with = "crate::utils::usize_as_u64")]
     pub(crate) number_of_resumption_psks: usize,
     /// Flag to indicate the Ratchet Tree Extension should be used
     pub(crate) use_ratchet_tree_extension: bool,

--- a/openmls/src/group/mls_group/past_secrets.rs
+++ b/openmls/src/group/mls_group/past_secrets.rs
@@ -1,12 +1,17 @@
 use std::collections::{HashMap, VecDeque};
 
+#[cfg(target_arch = "wasm32")]
+use web_time::SystemTime;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::SystemTime;
+
 use crate::schedule::message_secrets::MessageSecrets;
 
 use super::*;
 
 impl EpochTree {
     #[cfg(test)]
-    pub(crate) fn timestamp(&self) -> Option<std::time::SystemTime> {
+    pub(crate) fn timestamp(&self) -> Option<SystemTime> {
         self.message_secrets.timestamp()
     }
 }
@@ -72,7 +77,7 @@ impl MessageSecretsStore {
         Self {
             max_epochs,
             past_epoch_trees: VecDeque::new(),
-            message_secrets: message_secrets.with_timestamp(std::time::SystemTime::now()),
+            message_secrets: message_secrets.with_timestamp(SystemTime::now()),
         }
     }
 
@@ -97,7 +102,7 @@ impl MessageSecretsStore {
         &mut self,
         message_secrets: MessageSecrets,
     ) -> MessageSecrets {
-        let mut message_secrets = message_secrets.with_timestamp(std::time::SystemTime::now());
+        let mut message_secrets = message_secrets.with_timestamp(SystemTime::now());
         std::mem::swap(&mut self.message_secrets, &mut message_secrets);
 
         message_secrets
@@ -226,7 +231,7 @@ impl MessageSecretsStore {
     fn delete_past_epoch_secrets_older_than_duration(&mut self, duration: std::time::Duration) {
         // first, compare to the timestamp of the current message secrets
         if let Some(added_at) = self.message_secrets.timestamp() {
-            if let Ok(elapsed) = std::time::SystemTime::now().duration_since(added_at) {
+            if let Ok(elapsed) = SystemTime::now().duration_since(added_at) {
                 if elapsed > duration {
                     // delete all
                     self.past_epoch_trees.clear();
@@ -246,7 +251,7 @@ impl MessageSecretsStore {
                     return false;
                 };
 
-                let Ok(elapsed) = std::time::SystemTime::now().duration_since(added_at) else {
+                let Ok(elapsed) = SystemTime::now().duration_since(added_at) else {
                     return false;
                 };
 
@@ -263,7 +268,7 @@ impl MessageSecretsStore {
         }
     }
 
-    fn delete_past_epoch_secrets_before_timestamp(&mut self, cutoff: std::time::SystemTime) {
+    fn delete_past_epoch_secrets_before_timestamp(&mut self, cutoff: SystemTime) {
         // first, compare to timestamp of the current message secrets
         if let Some(added_at) = self.message_secrets.timestamp() {
             if added_at < cutoff {

--- a/openmls/src/group/mls_group/past_secrets.rs
+++ b/openmls/src/group/mls_group/past_secrets.rs
@@ -32,7 +32,10 @@ pub(crate) struct EpochTree {
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecretsStore {
-    // Maximum size of the `past_epoch_trees` list.
+    // Maximum size of the `past_epoch_trees` list. Serialized as `u64` so
+    // bytes are portable between 32-bit and 64-bit hosts (e.g. wasm32 ↔
+    // 64-bit servers).
+    #[serde(with = "crate::utils::usize_as_u64")]
     pub(crate) max_epochs: usize,
     // Past message secrets.
     // NOTE: these are in order of addition (latest at end).

--- a/openmls/src/group/mls_group/past_secrets.rs
+++ b/openmls/src/group/mls_group/past_secrets.rs
@@ -5,6 +5,8 @@ use web_time::SystemTime;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::SystemTime;
 
+use serde::{Deserialize, Serialize};
+
 use crate::schedule::message_secrets::MessageSecrets;
 
 use super::*;
@@ -16,7 +18,21 @@ impl EpochTree {
     }
 }
 
-// Internal helper struct
+// Internal helper struct.
+//
+// Wire layout (bincode/postcard positional) — IDENTICAL to upstream
+// openmls 0.7.x/0.8.x:
+//
+//   epoch:           u64
+//   message_secrets: MessageSecrets   (five upstream fields)
+//   leaves:          Vec<Member>
+//
+// IMPORTANT: do not add fields here. `EpochTree` is stored inside a
+// `VecDeque<EpochTree>` in `MessageSecretsStore`, so it is NOT at the tail of
+// the byte stream — a tolerantly-read trailing field would consume bytes from
+// the next `EpochTree` (or from a sibling field of the outer struct). Any
+// fork-only per-epoch metadata is carried in a parallel array on
+// `MessageSecretsStore` instead (see `past_epoch_added_at`).
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
@@ -28,20 +44,149 @@ pub(crate) struct EpochTree {
 
 /// Can store message secrets for up to `max_epochs`. The trees are added with [`self::add()`] and can be queried
 /// with [`Self::get_epoch()`].
-#[derive(Serialize, Deserialize)]
+///
+/// Persisted on-disk format. Wire layout (bincode/postcard positional):
+///
+///   max_epochs:           usize        (upstream — bincode native usize)
+///   past_epoch_trees:     VecDeque<EpochTree>
+///   message_secrets:      MessageSecrets   (five upstream fields)
+///   added_at:             Option<SystemTime>           ← fork-only tail
+///   past_epoch_added_at:  Vec<Option<SystemTime>>      ← fork-only tail
+///
+/// Both fork-only trailing fields are read tolerantly: missing-at-EOF or any
+/// deserialize error is treated as "absent" and replaced with `None`/empty.
+/// This is safe because they are at the END of the struct, so misreads cannot
+/// consume bytes belonging to siblings. On deserialize, `added_at` is
+/// re-hydrated onto `message_secrets.added_at` and `past_epoch_added_at`
+/// entries onto each `past_epoch_trees[i].message_secrets.added_at` so the
+/// rest of the codebase sees timestamps on `MessageSecrets` as before.
+///
+/// On serialize, `past_epoch_added_at` length always matches
+/// `past_epoch_trees.len()` (padded with `None` if a tree was added before
+/// any timestamp logic touched it).
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecretsStore {
-    // Maximum size of the `past_epoch_trees` list. Serialized as `u64` so
-    // bytes are portable between 32-bit and 64-bit hosts (e.g. wasm32 ↔
-    // 64-bit servers).
-    #[serde(with = "crate::utils::usize_as_u64")]
     pub(crate) max_epochs: usize,
-    // Past message secrets.
-    // NOTE: these are in order of addition (latest at end).
     past_epoch_trees: VecDeque<EpochTree>,
-    // The message secrets of the current epoch.
     message_secrets: MessageSecrets,
+}
+
+impl Serialize for MessageSecretsStore {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("MessageSecretsStore", 5)?;
+        s.serialize_field("max_epochs", &self.max_epochs)?;
+        s.serialize_field("past_epoch_trees", &self.past_epoch_trees)?;
+        s.serialize_field("message_secrets", &self.message_secrets)?;
+        s.serialize_field("added_at", &self.message_secrets.added_at)?;
+        let past_added_at: Vec<Option<SystemTime>> = self
+            .past_epoch_trees
+            .iter()
+            .map(|t| t.message_secrets.added_at)
+            .collect();
+        s.serialize_field("past_epoch_added_at", &past_added_at)?;
+        s.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for MessageSecretsStore {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        const FIELDS: &[&str] = &[
+            "max_epochs",
+            "past_epoch_trees",
+            "message_secrets",
+            "added_at",
+            "past_epoch_added_at",
+        ];
+        deserializer.deserialize_struct("MessageSecretsStore", FIELDS, MessageSecretsStoreVisitor)
+    }
+}
+
+struct MessageSecretsStoreVisitor;
+
+impl<'de> serde::de::Visitor<'de> for MessageSecretsStoreVisitor {
+    type Value = MessageSecretsStore;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("struct MessageSecretsStore")
+    }
+
+    fn visit_seq<A: serde::de::SeqAccess<'de>>(
+        self,
+        mut seq: A,
+    ) -> Result<MessageSecretsStore, A::Error> {
+        use serde::de::Error;
+        let max_epochs = seq
+            .next_element::<usize>()?
+            .ok_or_else(|| Error::missing_field("max_epochs"))?;
+        let mut past_epoch_trees = seq
+            .next_element::<VecDeque<EpochTree>>()?
+            .ok_or_else(|| Error::missing_field("past_epoch_trees"))?;
+        let mut message_secrets = seq
+            .next_element::<MessageSecrets>()?
+            .ok_or_else(|| Error::missing_field("message_secrets"))?;
+        // Tolerant tail #1: `added_at` for current message_secrets.
+        let added_at = seq
+            .next_element::<Option<SystemTime>>()
+            .unwrap_or(None)
+            .flatten();
+        message_secrets.added_at = added_at;
+        // Tolerant tail #2: per-past-epoch timestamps.
+        let past_added_at: Vec<Option<SystemTime>> = seq
+            .next_element::<Vec<Option<SystemTime>>>()
+            .unwrap_or(None)
+            .unwrap_or_default();
+        for (i, tree) in past_epoch_trees.iter_mut().enumerate() {
+            tree.message_secrets.added_at = past_added_at.get(i).copied().unwrap_or(None);
+        }
+        Ok(MessageSecretsStore {
+            max_epochs,
+            past_epoch_trees,
+            message_secrets,
+        })
+    }
+
+    fn visit_map<A: serde::de::MapAccess<'de>>(
+        self,
+        mut map: A,
+    ) -> Result<MessageSecretsStore, A::Error> {
+        use serde::de::Error;
+        let mut max_epochs: Option<usize> = None;
+        let mut past_epoch_trees: Option<VecDeque<EpochTree>> = None;
+        let mut message_secrets: Option<MessageSecrets> = None;
+        let mut added_at: Option<Option<SystemTime>> = None;
+        let mut past_epoch_added_at: Option<Vec<Option<SystemTime>>> = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "max_epochs" => max_epochs = Some(map.next_value()?),
+                "past_epoch_trees" => past_epoch_trees = Some(map.next_value()?),
+                "message_secrets" => message_secrets = Some(map.next_value()?),
+                "added_at" => added_at = Some(map.next_value()?),
+                "past_epoch_added_at" => past_epoch_added_at = Some(map.next_value()?),
+                _ => {
+                    let _: serde::de::IgnoredAny = map.next_value()?;
+                }
+            }
+        }
+
+        let mut message_secrets =
+            message_secrets.ok_or_else(|| Error::missing_field("message_secrets"))?;
+        message_secrets.added_at = added_at.unwrap_or(None);
+        let mut past_epoch_trees =
+            past_epoch_trees.ok_or_else(|| Error::missing_field("past_epoch_trees"))?;
+        if let Some(past_added_at) = past_epoch_added_at {
+            for (i, tree) in past_epoch_trees.iter_mut().enumerate() {
+                tree.message_secrets.added_at = past_added_at.get(i).copied().unwrap_or(None);
+            }
+        }
+        Ok(MessageSecretsStore {
+            max_epochs: max_epochs.ok_or_else(|| Error::missing_field("max_epochs"))?,
+            past_epoch_trees,
+            message_secrets,
+        })
+    }
 }
 
 #[cfg(not(feature = "crypto-debug"))]

--- a/openmls/src/group/mls_group/proposal_store.rs
+++ b/openmls/src/group/mls_group/proposal_store.rs
@@ -637,6 +637,9 @@ impl ProposalQueue {
                     // have to be checked by the application instead.
                     valid_proposals.add(queued_proposal.proposal_reference());
                 }
+                // Hidden placeholder kept only for serde wire-format
+                // stability; the library does not produce this variant.
+                Proposal::_AppAck => {}
             }
         }
 

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -809,7 +809,18 @@ impl StagedCommit {
 }
 
 /// This struct is used internally by [`StagedCommit`] to encapsulate all the modified group state.
-#[derive(Debug, Serialize, Deserialize)]
+//
+// IMPORTANT: this struct is reachable from the persisted on-disk format
+// (`MlsGroupState::PendingCommit(...)` → `PendingCommitState::Member(...)` →
+// `StagedCommit::state` → `StagedCommitState::GroupMember(...)`). The first
+// six fields are the openmls-0.7.x shape and MUST NOT be reordered or have
+// fields inserted between them. The trailing `application_export_tree` field
+// is gated by `extensions-draft-08` and is deserialized *tolerantly*: see the
+// custom `Deserialize` impl below for the EOF-tolerant fallback rationale.
+// The same caveat as `MessageSecrets` applies: this must remain the last
+// field of any containing struct for non-self-describing formats to handle
+// the absence of the field cleanly.
+#[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
 pub(crate) struct MemberStagedCommitState {
     group_epoch_secrets: GroupEpochSecrets,
@@ -819,10 +830,190 @@ pub(crate) struct MemberStagedCommitState {
     new_leaf_keypair_option: Option<EncryptionKeyPair>,
     update_path_leaf_node: Option<LeafNode>,
     #[cfg(feature = "extensions-draft-08")]
-    #[serde(default)]
     // This is `None` only if the group was stored using an older version of
     // OpenMLS that did not support the application exporter.
     application_export_tree: Option<ApplicationExportTree>,
+}
+
+const MEMBER_STAGED_COMMIT_STATE_FIELDS: &[&str] = &[
+    "group_epoch_secrets",
+    "message_secrets",
+    "staged_diff",
+    "new_keypairs",
+    "new_leaf_keypair_option",
+    "update_path_leaf_node",
+    #[cfg(feature = "extensions-draft-08")]
+    "application_export_tree",
+];
+
+impl Serialize for MemberStagedCommitState {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut s = serializer.serialize_struct(
+            "MemberStagedCommitState",
+            MEMBER_STAGED_COMMIT_STATE_FIELDS.len(),
+        )?;
+        s.serialize_field("group_epoch_secrets", &self.group_epoch_secrets)?;
+        s.serialize_field("message_secrets", &self.message_secrets)?;
+        s.serialize_field("staged_diff", &self.staged_diff)?;
+        s.serialize_field("new_keypairs", &self.new_keypairs)?;
+        s.serialize_field("new_leaf_keypair_option", &self.new_leaf_keypair_option)?;
+        s.serialize_field("update_path_leaf_node", &self.update_path_leaf_node)?;
+        #[cfg(feature = "extensions-draft-08")]
+        s.serialize_field("application_export_tree", &self.application_export_tree)?;
+        s.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for MemberStagedCommitState {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_struct(
+            "MemberStagedCommitState",
+            MEMBER_STAGED_COMMIT_STATE_FIELDS,
+            MemberStagedCommitStateVisitor,
+        )
+    }
+}
+
+struct MemberStagedCommitStateVisitor;
+
+impl<'de> serde::de::Visitor<'de> for MemberStagedCommitStateVisitor {
+    type Value = MemberStagedCommitState;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("struct MemberStagedCommitState")
+    }
+
+    fn visit_seq<A: serde::de::SeqAccess<'de>>(
+        self,
+        mut seq: A,
+    ) -> Result<MemberStagedCommitState, A::Error> {
+        use serde::de::Error;
+
+        let group_epoch_secrets = seq
+            .next_element::<GroupEpochSecrets>()?
+            .ok_or_else(|| Error::missing_field("group_epoch_secrets"))?;
+        let message_secrets = seq
+            .next_element::<MessageSecrets>()?
+            .ok_or_else(|| Error::missing_field("message_secrets"))?;
+        let staged_diff = seq
+            .next_element::<StagedPublicGroupDiff>()?
+            .ok_or_else(|| Error::missing_field("staged_diff"))?;
+        let new_keypairs = seq
+            .next_element::<Vec<EncryptionKeyPair>>()?
+            .ok_or_else(|| Error::missing_field("new_keypairs"))?;
+        let new_leaf_keypair_option = seq
+            .next_element::<Option<EncryptionKeyPair>>()?
+            .ok_or_else(|| Error::missing_field("new_leaf_keypair_option"))?;
+        let update_path_leaf_node = seq
+            .next_element::<Option<LeafNode>>()?
+            .ok_or_else(|| Error::missing_field("update_path_leaf_node"))?;
+
+        // Tolerant tail read for `application_export_tree`: feature-gated and
+        // possibly absent in data written by openmls < 0.8 (when the feature
+        // did not yet exist) or by builds without the feature enabled. Any
+        // error from `next_element` (e.g. bincode EOF) is treated as "field
+        // absent" and falls back to `None`.
+        #[cfg(feature = "extensions-draft-08")]
+        let application_export_tree = seq
+            .next_element::<Option<ApplicationExportTree>>()
+            .unwrap_or(None)
+            .flatten();
+
+        Ok(MemberStagedCommitState {
+            group_epoch_secrets,
+            message_secrets,
+            staged_diff,
+            new_keypairs,
+            new_leaf_keypair_option,
+            update_path_leaf_node,
+            #[cfg(feature = "extensions-draft-08")]
+            application_export_tree,
+        })
+    }
+
+    fn visit_map<A: serde::de::MapAccess<'de>>(
+        self,
+        mut map: A,
+    ) -> Result<MemberStagedCommitState, A::Error> {
+        use serde::de::Error;
+
+        let mut group_epoch_secrets: Option<GroupEpochSecrets> = None;
+        let mut message_secrets: Option<MessageSecrets> = None;
+        let mut staged_diff: Option<StagedPublicGroupDiff> = None;
+        let mut new_keypairs: Option<Vec<EncryptionKeyPair>> = None;
+        let mut new_leaf_keypair_option: Option<Option<EncryptionKeyPair>> = None;
+        let mut update_path_leaf_node: Option<Option<LeafNode>> = None;
+        #[cfg(feature = "extensions-draft-08")]
+        let mut application_export_tree: Option<Option<ApplicationExportTree>> = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "group_epoch_secrets" => {
+                    if group_epoch_secrets.is_some() {
+                        return Err(Error::duplicate_field("group_epoch_secrets"));
+                    }
+                    group_epoch_secrets = Some(map.next_value()?);
+                }
+                "message_secrets" => {
+                    if message_secrets.is_some() {
+                        return Err(Error::duplicate_field("message_secrets"));
+                    }
+                    message_secrets = Some(map.next_value()?);
+                }
+                "staged_diff" => {
+                    if staged_diff.is_some() {
+                        return Err(Error::duplicate_field("staged_diff"));
+                    }
+                    staged_diff = Some(map.next_value()?);
+                }
+                "new_keypairs" => {
+                    if new_keypairs.is_some() {
+                        return Err(Error::duplicate_field("new_keypairs"));
+                    }
+                    new_keypairs = Some(map.next_value()?);
+                }
+                "new_leaf_keypair_option" => {
+                    if new_leaf_keypair_option.is_some() {
+                        return Err(Error::duplicate_field("new_leaf_keypair_option"));
+                    }
+                    new_leaf_keypair_option = Some(map.next_value()?);
+                }
+                "update_path_leaf_node" => {
+                    if update_path_leaf_node.is_some() {
+                        return Err(Error::duplicate_field("update_path_leaf_node"));
+                    }
+                    update_path_leaf_node = Some(map.next_value()?);
+                }
+                #[cfg(feature = "extensions-draft-08")]
+                "application_export_tree" => {
+                    if application_export_tree.is_some() {
+                        return Err(Error::duplicate_field("application_export_tree"));
+                    }
+                    application_export_tree = Some(map.next_value()?);
+                }
+                _ => {
+                    let _: serde::de::IgnoredAny = map.next_value()?;
+                }
+            }
+        }
+
+        Ok(MemberStagedCommitState {
+            group_epoch_secrets: group_epoch_secrets
+                .ok_or_else(|| Error::missing_field("group_epoch_secrets"))?,
+            message_secrets: message_secrets
+                .ok_or_else(|| Error::missing_field("message_secrets"))?,
+            staged_diff: staged_diff.ok_or_else(|| Error::missing_field("staged_diff"))?,
+            new_keypairs: new_keypairs.ok_or_else(|| Error::missing_field("new_keypairs"))?,
+            new_leaf_keypair_option: new_leaf_keypair_option
+                .ok_or_else(|| Error::missing_field("new_leaf_keypair_option"))?,
+            update_path_leaf_node: update_path_leaf_node
+                .ok_or_else(|| Error::missing_field("update_path_leaf_node"))?,
+            #[cfg(feature = "extensions-draft-08")]
+            application_export_tree: application_export_tree.unwrap_or(None),
+        })
+    }
 }
 
 impl MemberStagedCommitState {

--- a/openmls/src/group/mls_group/tests_and_kats/tests/past_secrets.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/past_secrets.rs
@@ -30,6 +30,11 @@ use crate::{
 };
 use std::time::Duration;
 
+#[cfg(target_arch = "wasm32")]
+use web_time::{Instant, SystemTime};
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::{Instant, SystemTime};
+
 const INTERVAL: Duration = Duration::from_millis(100);
 
 /// Helper function to set up an MlsGroup configured with the provided past epoch deletion policy
@@ -108,7 +113,7 @@ fn max_epochs_with_duration<Provider: crate::storage::OpenMlsProvider>(
     let (alice_provider, alice_signer, mut alice_group) =
         setup::<Provider>(ciphersuite, policy.clone());
 
-    let start = std::time::Instant::now();
+    let start = Instant::now();
 
     // apply and merge commits to advance the group epoch
     apply_and_merge_commits(4, &alice_provider, &alice_signer, &mut alice_group, policy);
@@ -152,7 +157,7 @@ fn max_epochs_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>()
 
     // === Test the `delete_past_epoch_secrets()` API with a timestamp ===
 
-    let start = std::time::SystemTime::now();
+    let start = SystemTime::now();
 
     // apply and merge commits to advance the group epoch
     apply_and_merge_commits(4, &alice_provider, &alice_signer, &mut alice_group, policy);
@@ -189,7 +194,7 @@ fn max_epochs_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>()
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::now()),
+            PastEpochDeletion::before_timestamp(SystemTime::now()),
         )
         .expect("error deleting past epoch secrets");
     // assert all past secrets deleted
@@ -222,7 +227,7 @@ fn keep_all_policy_with_duration<Provider: crate::storage::OpenMlsProvider>(
     let (alice_provider, alice_signer, mut alice_group) =
         setup::<Provider>(ciphersuite, policy.clone());
 
-    let start = std::time::Instant::now();
+    let start = Instant::now();
 
     // apply and merge commits to advance the group epoch
     apply_and_merge_commits(4, &alice_provider, &alice_signer, &mut alice_group, policy);
@@ -275,7 +280,7 @@ fn keep_all_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>(
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::UNIX_EPOCH)
+            PastEpochDeletion::before_timestamp(SystemTime::UNIX_EPOCH)
                 .max_past_epochs(5),
         )
         .expect("error deleting past epoch secrets");
@@ -289,7 +294,7 @@ fn keep_all_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>(
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::UNIX_EPOCH)
+            PastEpochDeletion::before_timestamp(SystemTime::UNIX_EPOCH)
                 .max_past_epochs(3),
         )
         .expect("error deleting past epoch secrets");
@@ -303,7 +308,7 @@ fn keep_all_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>(
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::UNIX_EPOCH)
+            PastEpochDeletion::before_timestamp(SystemTime::UNIX_EPOCH)
                 .max_past_epochs(1),
         )
         .expect("error deleting past epoch secrets");
@@ -317,7 +322,7 @@ fn keep_all_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>(
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::now()),
+            PastEpochDeletion::before_timestamp(SystemTime::now()),
         )
         .expect("error deleting past epoch secrets");
     // assert all past secrets deleted
@@ -382,7 +387,7 @@ fn delete_all<Provider: crate::storage::OpenMlsProvider>() {
 fn setup_tree_store_with_timestamps<Provider: OpenMlsProvider>(
     ciphersuite: Ciphersuite,
     provider: &Provider,
-    entries: &[Option<std::time::SystemTime>],
+    entries: &[Option<SystemTime>],
 ) -> MessageSecretsStore {
     // Create a store
     let mut message_secrets_store = MessageSecretsStore::new_with_secret(
@@ -586,13 +591,13 @@ fn test_secret_tree_store_migration_next_epoch_timestamp() {
 
     // test deletion of all message secrets before the timestamp
     message_secrets_store.delete_past_epoch_secrets(PastEpochDeletion::before_timestamp(
-        std::time::SystemTime::UNIX_EPOCH,
+        SystemTime::UNIX_EPOCH,
     ));
     assert_eq!(message_secrets_store.num_past_epoch_trees(), 2);
 
     // test deletion of all message secrets before the timestamp
     message_secrets_store.delete_past_epoch_secrets(PastEpochDeletion::before_timestamp(
-        std::time::SystemTime::now(),
+        SystemTime::now(),
     ));
     assert_eq!(message_secrets_store.num_past_epoch_trees(), 0);
 }
@@ -634,7 +639,7 @@ fn test_secret_tree_store_migration_next_epoch_duration() {
 fn test_secret_tree_store_mixed_delete_by_timestamp() {
     let provider = &Provider::default();
 
-    let timestamp_before = std::time::SystemTime::now();
+    let timestamp_before = SystemTime::now();
 
     // Set up a secret tree store with mixed Some and None timestamps
     // NOTE: For completeness, this sequence of epoch tree timestamps is tested.
@@ -644,11 +649,11 @@ fn test_secret_tree_store_mixed_delete_by_timestamp() {
         provider,
         &[
             None,                                    //0
-            Some(std::time::SystemTime::UNIX_EPOCH), //1
+            Some(SystemTime::UNIX_EPOCH), //1
             None,                                    //2
-            Some(std::time::SystemTime::UNIX_EPOCH), //3
+            Some(SystemTime::UNIX_EPOCH), //3
             None,                                    //4
-            Some(std::time::SystemTime::now()),      //5
+            Some(SystemTime::now()),      //5
             None,                                    //6
         ],
     );
@@ -680,11 +685,11 @@ fn test_secret_tree_store_mixed_delete_by_duration() {
         provider,
         &[
             None,                                    //0
-            Some(std::time::SystemTime::UNIX_EPOCH), //1
+            Some(SystemTime::UNIX_EPOCH), //1
             None,                                    //2
-            Some(std::time::SystemTime::UNIX_EPOCH), //3
+            Some(SystemTime::UNIX_EPOCH), //3
             None,                                    //4
-            Some(std::time::SystemTime::now()),      //5
+            Some(SystemTime::now()),      //5
             None,                                    //6
         ],
     );
@@ -717,7 +722,7 @@ fn test_secret_tree_store() {
     message_secrets_store.add_past_epoch_tree(
         0,
         MessageSecrets::random(ciphersuite, provider.rand(), LeafNodeIndex::new(0))
-            .with_timestamp(std::time::SystemTime::now()),
+            .with_timestamp(SystemTime::now()),
         Vec::new(),
     );
 
@@ -729,7 +734,7 @@ fn test_secret_tree_store() {
         message_secrets_store.add_past_epoch_tree(
             i,
             MessageSecrets::random(ciphersuite, provider.rand(), LeafNodeIndex::new(0))
-                .with_timestamp(std::time::SystemTime::now()),
+                .with_timestamp(SystemTime::now()),
             Vec::new(),
         );
     }
@@ -759,7 +764,7 @@ fn test_empty_secret_tree_store() {
     message_secrets_store.add_past_epoch_tree(
         0,
         MessageSecrets::random(ciphersuite, provider.rand(), LeafNodeIndex::new(0))
-            .with_timestamp(std::time::SystemTime::now()),
+            .with_timestamp(SystemTime::now()),
         Vec::new(),
     );
 

--- a/openmls/src/key_packages/lifetime.rs
+++ b/openmls/src/key_packages/lifetime.rs
@@ -1,5 +1,5 @@
 #[cfg(target_arch = "wasm32")]
-use fluvio_wasm_timer::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -138,7 +138,7 @@ impl Default for Lifetime {
 mod tests {
     use core::time::Duration;
     #[cfg(target_arch = "wasm32")]
-    use fluvio_wasm_timer::SystemTime;
+    use web_time::SystemTime;
     #[cfg(not(target_arch = "wasm32"))]
     use std::time::SystemTime;
 

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -29,12 +29,13 @@ impl Size for Proposal {
                 Proposal::ReInit(p) => p.tls_serialized_len(),
                 Proposal::ExternalInit(p) => p.tls_serialized_len(),
                 Proposal::GroupContextExtensions(p) => p.tls_serialized_len(),
+                Proposal::_AppAck => 0,
+                Proposal::SelfRemove => 0,
+                Proposal::Custom(p) => p.payload().tls_serialized_len(),
                 #[cfg(feature = "extensions-draft-08")]
                 Proposal::AppDataUpdate(p) => p.tls_serialized_len(),
-                Proposal::SelfRemove => 0,
                 #[cfg(feature = "extensions-draft-08")]
                 Proposal::AppEphemeral(p) => p.tls_serialized_len(),
-                Proposal::Custom(p) => p.payload().tls_serialized_len(),
             }
     }
 }
@@ -50,12 +51,13 @@ impl Serialize for Proposal {
             Proposal::ReInit(p) => p.tls_serialize(writer),
             Proposal::ExternalInit(p) => p.tls_serialize(writer),
             Proposal::GroupContextExtensions(p) => p.tls_serialize(writer),
+            Proposal::_AppAck => Ok(0),
+            Proposal::SelfRemove => Ok(0),
+            Proposal::Custom(p) => p.payload().tls_serialize(writer),
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppDataUpdate(p) => p.tls_serialize(writer),
-            Proposal::SelfRemove => Ok(0),
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(p) => p.tls_serialize(writer),
-            Proposal::Custom(p) => p.payload().tls_serialize(writer),
         }
         .map(|l| written + l)
     }
@@ -155,6 +157,13 @@ impl Deserialize for ProposalIn {
                 let payload = Vec::<u8>::tls_deserialize(bytes)?;
                 let custom_proposal = CustomProposal::new(proposal_type.into(), payload);
                 ProposalIn::Custom(Box::new(custom_proposal))
+            }
+            // `_AppAck` is a hidden placeholder kept only to preserve serde
+            // variant indices; `ProposalType::from(u16)` never produces it.
+            ProposalType::_AppAck => {
+                return Err(tls_codec::Error::DecodingError(
+                    "AppAck proposals are not supported".to_string(),
+                ));
             }
         };
         Ok(proposal)

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -72,10 +72,7 @@ use crate::component::ComponentId;
 /// |:=======|:==============|:============|:==============|:==========|:=============================|
 /// | 0x0009 | app_ephemeral | Y           | N             | RFC XXXX  | draft-ietf-mls-extensions-08 |
 /// | 0x000a | self_remove   | Y           | Y             | RFC XXXX  | draft-ietf-mls-extensions-07 |
-// Variant order is part of the serde wire format for non-self-describing
-// serializers like bincode. Do not reorder existing variants; append new
-// variants at the end of the enum.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash)]
 #[allow(missing_docs)]
 pub enum ProposalType {
     Add,
@@ -86,22 +83,226 @@ pub enum ProposalType {
     ExternalInit,
     GroupContextExtensions,
     // Placeholder for the removed `AppAck` variant. Kept (hidden) to preserve
-    // the serde variant indices of subsequent variants for non-self-describing
-    // formats. `AppAck` was never produced by the library on the wire, so no
-    // real data should round-trip through this variant.
+    // the serde variant index for subsequent variants. `AppAck` was never
+    // produced by the library, so no real data round-trips through it.
     #[doc(hidden)]
-    #[serde(rename = "AppAck")]
     _AppAck,
     SelfRemove,
     Custom(u16),
-    // --- Variants appended after openmls-0.7.x ---
-    // New variants MUST be added below this line to preserve the serde wire
-    // format with older persisted data.
     Grease(u16),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral,
     #[cfg(feature = "extensions-draft-08")]
     AppDataUpdate,
+}
+
+// Manual serde impls with explicit variant indices. See the comment on
+// `CredentialType` in `credentials/mod.rs` for the rationale. The `_AppAck`
+// placeholder serializes/deserializes under the historical name "AppAck" so
+// the JSON wire format also stays stable across the removal of the variant.
+const PROPOSAL_TYPE_VARIANTS: &[&str] = &[
+    "Add",
+    "Update",
+    "Remove",
+    "PreSharedKey",
+    "Reinit",
+    "ExternalInit",
+    "GroupContextExtensions",
+    "AppAck",
+    "SelfRemove",
+    "Custom",
+    "Grease",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppEphemeral",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppDataUpdate",
+];
+
+impl Serialize for ProposalType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Add => serializer.serialize_unit_variant("ProposalType", 0, "Add"),
+            Self::Update => serializer.serialize_unit_variant("ProposalType", 1, "Update"),
+            Self::Remove => serializer.serialize_unit_variant("ProposalType", 2, "Remove"),
+            Self::PreSharedKey => {
+                serializer.serialize_unit_variant("ProposalType", 3, "PreSharedKey")
+            }
+            Self::Reinit => serializer.serialize_unit_variant("ProposalType", 4, "Reinit"),
+            Self::ExternalInit => {
+                serializer.serialize_unit_variant("ProposalType", 5, "ExternalInit")
+            }
+            Self::GroupContextExtensions => {
+                serializer.serialize_unit_variant("ProposalType", 6, "GroupContextExtensions")
+            }
+            Self::_AppAck => serializer.serialize_unit_variant("ProposalType", 7, "AppAck"),
+            Self::SelfRemove => serializer.serialize_unit_variant("ProposalType", 8, "SelfRemove"),
+            Self::Custom(v) => serializer.serialize_newtype_variant("ProposalType", 9, "Custom", v),
+            Self::Grease(v) => {
+                serializer.serialize_newtype_variant("ProposalType", 10, "Grease", v)
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppEphemeral => {
+                serializer.serialize_unit_variant("ProposalType", 11, "AppEphemeral")
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppDataUpdate => {
+                serializer.serialize_unit_variant("ProposalType", 12, "AppDataUpdate")
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ProposalType {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum("ProposalType", PROPOSAL_TYPE_VARIANTS, ProposalTypeVisitor)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ProposalTypeId {
+    Add,
+    Update,
+    Remove,
+    PreSharedKey,
+    Reinit,
+    ExternalInit,
+    GroupContextExtensions,
+    AppAck,
+    SelfRemove,
+    Custom,
+    Grease,
+    #[cfg(feature = "extensions-draft-08")]
+    AppEphemeral,
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataUpdate,
+}
+
+impl<'de> Deserialize<'de> for ProposalTypeId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = ProposalTypeId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("ProposalType variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(ProposalTypeId::Add),
+                    1 => Ok(ProposalTypeId::Update),
+                    2 => Ok(ProposalTypeId::Remove),
+                    3 => Ok(ProposalTypeId::PreSharedKey),
+                    4 => Ok(ProposalTypeId::Reinit),
+                    5 => Ok(ProposalTypeId::ExternalInit),
+                    6 => Ok(ProposalTypeId::GroupContextExtensions),
+                    7 => Ok(ProposalTypeId::AppAck),
+                    8 => Ok(ProposalTypeId::SelfRemove),
+                    9 => Ok(ProposalTypeId::Custom),
+                    10 => Ok(ProposalTypeId::Grease),
+                    #[cfg(feature = "extensions-draft-08")]
+                    11 => Ok(ProposalTypeId::AppEphemeral),
+                    #[cfg(feature = "extensions-draft-08")]
+                    12 => Ok(ProposalTypeId::AppDataUpdate),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"valid ProposalType variant index",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "Add" => Ok(ProposalTypeId::Add),
+                    "Update" => Ok(ProposalTypeId::Update),
+                    "Remove" => Ok(ProposalTypeId::Remove),
+                    "PreSharedKey" => Ok(ProposalTypeId::PreSharedKey),
+                    "Reinit" => Ok(ProposalTypeId::Reinit),
+                    "ExternalInit" => Ok(ProposalTypeId::ExternalInit),
+                    "GroupContextExtensions" => Ok(ProposalTypeId::GroupContextExtensions),
+                    "AppAck" => Ok(ProposalTypeId::AppAck),
+                    "SelfRemove" => Ok(ProposalTypeId::SelfRemove),
+                    "Custom" => Ok(ProposalTypeId::Custom),
+                    "Grease" => Ok(ProposalTypeId::Grease),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppEphemeral" => Ok(ProposalTypeId::AppEphemeral),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppDataUpdate" => Ok(ProposalTypeId::AppDataUpdate),
+                    other => Err(E::unknown_variant(other, PROPOSAL_TYPE_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct ProposalTypeVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ProposalTypeVisitor {
+    type Value = ProposalType;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum ProposalType")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<ProposalTypeId>()?;
+        match variant {
+            ProposalTypeId::Add => {
+                access.unit_variant()?;
+                Ok(ProposalType::Add)
+            }
+            ProposalTypeId::Update => {
+                access.unit_variant()?;
+                Ok(ProposalType::Update)
+            }
+            ProposalTypeId::Remove => {
+                access.unit_variant()?;
+                Ok(ProposalType::Remove)
+            }
+            ProposalTypeId::PreSharedKey => {
+                access.unit_variant()?;
+                Ok(ProposalType::PreSharedKey)
+            }
+            ProposalTypeId::Reinit => {
+                access.unit_variant()?;
+                Ok(ProposalType::Reinit)
+            }
+            ProposalTypeId::ExternalInit => {
+                access.unit_variant()?;
+                Ok(ProposalType::ExternalInit)
+            }
+            ProposalTypeId::GroupContextExtensions => {
+                access.unit_variant()?;
+                Ok(ProposalType::GroupContextExtensions)
+            }
+            ProposalTypeId::AppAck => {
+                access.unit_variant()?;
+                Ok(ProposalType::_AppAck)
+            }
+            ProposalTypeId::SelfRemove => {
+                access.unit_variant()?;
+                Ok(ProposalType::SelfRemove)
+            }
+            ProposalTypeId::Custom => Ok(ProposalType::Custom(access.newtype_variant()?)),
+            ProposalTypeId::Grease => Ok(ProposalType::Grease(access.newtype_variant()?)),
+            #[cfg(feature = "extensions-draft-08")]
+            ProposalTypeId::AppEphemeral => {
+                access.unit_variant()?;
+                Ok(ProposalType::AppEphemeral)
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            ProposalTypeId::AppDataUpdate => {
+                access.unit_variant()?;
+                Ok(ProposalType::AppDataUpdate)
+            }
+        }
+    }
 }
 
 impl ProposalType {
@@ -248,10 +449,7 @@ impl From<ProposalType> for u16 {
 ///     };
 /// } Proposal;
 /// ```
-// Variant order is part of the serde wire format for non-self-describing
-// serializers like bincode. Do not reorder existing variants; append new
-// variants at the end of the enum.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(missing_docs)]
 #[repr(u16)]
 pub enum Proposal {
@@ -263,23 +461,192 @@ pub enum Proposal {
     ExternalInit(Box<ExternalInitProposal>),
     GroupContextExtensions(Box<GroupContextExtensionProposal>),
     // Placeholder for the removed `AppAck(Box<AppAckProposal>)` variant. Kept
-    // (hidden) to preserve the serde variant indices of subsequent variants
-    // for non-self-describing formats. The library never produced `AppAck`
-    // proposals, so no real persisted data should round-trip through this
-    // variant; constructing it directly is unsupported.
+    // (hidden) to preserve the serde variant index for subsequent variants.
+    // The library never produced `AppAck` proposals.
     #[doc(hidden)]
-    #[serde(rename = "AppAck")]
     _AppAck,
-    // A SelfRemove proposal is an empty struct.
     SelfRemove,
     Custom(Box<CustomProposal>),
-    // --- Variants appended after openmls-0.7.x ---
-    // New variants MUST be added below this line to preserve the serde wire
-    // format with older persisted data.
     #[cfg(feature = "extensions-draft-08")]
     AppDataUpdate(Box<AppDataUpdateProposal>),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral(Box<AppEphemeralProposal>),
+}
+
+// Manual serde impls with explicit variant indices. See the comment on
+// `CredentialType` in `credentials/mod.rs` for the rationale. `_AppAck`
+// serializes/deserializes under the historical name "AppAck" so the JSON
+// wire format stays stable across the removal of the variant.
+const PROPOSAL_VARIANTS: &[&str] = &[
+    "Add",
+    "Update",
+    "Remove",
+    "PreSharedKey",
+    "ReInit",
+    "ExternalInit",
+    "GroupContextExtensions",
+    "AppAck",
+    "SelfRemove",
+    "Custom",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppDataUpdate",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppEphemeral",
+];
+
+impl Serialize for Proposal {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Add(p) => serializer.serialize_newtype_variant("Proposal", 0, "Add", p),
+            Self::Update(p) => serializer.serialize_newtype_variant("Proposal", 1, "Update", p),
+            Self::Remove(p) => serializer.serialize_newtype_variant("Proposal", 2, "Remove", p),
+            Self::PreSharedKey(p) => {
+                serializer.serialize_newtype_variant("Proposal", 3, "PreSharedKey", p)
+            }
+            Self::ReInit(p) => serializer.serialize_newtype_variant("Proposal", 4, "ReInit", p),
+            Self::ExternalInit(p) => {
+                serializer.serialize_newtype_variant("Proposal", 5, "ExternalInit", p)
+            }
+            Self::GroupContextExtensions(p) => {
+                serializer.serialize_newtype_variant("Proposal", 6, "GroupContextExtensions", p)
+            }
+            Self::_AppAck => serializer.serialize_unit_variant("Proposal", 7, "AppAck"),
+            Self::SelfRemove => serializer.serialize_unit_variant("Proposal", 8, "SelfRemove"),
+            Self::Custom(p) => serializer.serialize_newtype_variant("Proposal", 9, "Custom", p),
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppDataUpdate(p) => {
+                serializer.serialize_newtype_variant("Proposal", 10, "AppDataUpdate", p)
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppEphemeral(p) => {
+                serializer.serialize_newtype_variant("Proposal", 11, "AppEphemeral", p)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Proposal {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum("Proposal", PROPOSAL_VARIANTS, ProposalVisitor)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ProposalId {
+    Add,
+    Update,
+    Remove,
+    PreSharedKey,
+    ReInit,
+    ExternalInit,
+    GroupContextExtensions,
+    AppAck,
+    SelfRemove,
+    Custom,
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataUpdate,
+    #[cfg(feature = "extensions-draft-08")]
+    AppEphemeral,
+}
+
+impl<'de> Deserialize<'de> for ProposalId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = ProposalId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("Proposal variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(ProposalId::Add),
+                    1 => Ok(ProposalId::Update),
+                    2 => Ok(ProposalId::Remove),
+                    3 => Ok(ProposalId::PreSharedKey),
+                    4 => Ok(ProposalId::ReInit),
+                    5 => Ok(ProposalId::ExternalInit),
+                    6 => Ok(ProposalId::GroupContextExtensions),
+                    7 => Ok(ProposalId::AppAck),
+                    8 => Ok(ProposalId::SelfRemove),
+                    9 => Ok(ProposalId::Custom),
+                    #[cfg(feature = "extensions-draft-08")]
+                    10 => Ok(ProposalId::AppDataUpdate),
+                    #[cfg(feature = "extensions-draft-08")]
+                    11 => Ok(ProposalId::AppEphemeral),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"valid Proposal variant index",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "Add" => Ok(ProposalId::Add),
+                    "Update" => Ok(ProposalId::Update),
+                    "Remove" => Ok(ProposalId::Remove),
+                    "PreSharedKey" => Ok(ProposalId::PreSharedKey),
+                    "ReInit" => Ok(ProposalId::ReInit),
+                    "ExternalInit" => Ok(ProposalId::ExternalInit),
+                    "GroupContextExtensions" => Ok(ProposalId::GroupContextExtensions),
+                    "AppAck" => Ok(ProposalId::AppAck),
+                    "SelfRemove" => Ok(ProposalId::SelfRemove),
+                    "Custom" => Ok(ProposalId::Custom),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppDataUpdate" => Ok(ProposalId::AppDataUpdate),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppEphemeral" => Ok(ProposalId::AppEphemeral),
+                    other => Err(E::unknown_variant(other, PROPOSAL_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct ProposalVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ProposalVisitor {
+    type Value = Proposal;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum Proposal")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<ProposalId>()?;
+        match variant {
+            ProposalId::Add => Ok(Proposal::Add(access.newtype_variant()?)),
+            ProposalId::Update => Ok(Proposal::Update(access.newtype_variant()?)),
+            ProposalId::Remove => Ok(Proposal::Remove(access.newtype_variant()?)),
+            ProposalId::PreSharedKey => Ok(Proposal::PreSharedKey(access.newtype_variant()?)),
+            ProposalId::ReInit => Ok(Proposal::ReInit(access.newtype_variant()?)),
+            ProposalId::ExternalInit => Ok(Proposal::ExternalInit(access.newtype_variant()?)),
+            ProposalId::GroupContextExtensions => {
+                Ok(Proposal::GroupContextExtensions(access.newtype_variant()?))
+            }
+            ProposalId::AppAck => {
+                access.unit_variant()?;
+                Ok(Proposal::_AppAck)
+            }
+            ProposalId::SelfRemove => {
+                access.unit_variant()?;
+                Ok(Proposal::SelfRemove)
+            }
+            ProposalId::Custom => Ok(Proposal::Custom(access.newtype_variant()?)),
+            #[cfg(feature = "extensions-draft-08")]
+            ProposalId::AppDataUpdate => Ok(Proposal::AppDataUpdate(access.newtype_variant()?)),
+            #[cfg(feature = "extensions-draft-08")]
+            ProposalId::AppEphemeral => Ok(Proposal::AppEphemeral(access.newtype_variant()?)),
+        }
+    }
 }
 
 impl Proposal {

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -72,6 +72,9 @@ use crate::component::ComponentId;
 /// |:=======|:==============|:============|:==============|:==========|:=============================|
 /// | 0x0009 | app_ephemeral | Y           | N             | RFC XXXX  | draft-ietf-mls-extensions-08 |
 /// | 0x000a | self_remove   | Y           | Y             | RFC XXXX  | draft-ietf-mls-extensions-07 |
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
 #[allow(missing_docs)]
 pub enum ProposalType {
@@ -82,13 +85,23 @@ pub enum ProposalType {
     Reinit,
     ExternalInit,
     GroupContextExtensions,
+    // Placeholder for the removed `AppAck` variant. Kept (hidden) to preserve
+    // the serde variant indices of subsequent variants for non-self-describing
+    // formats. `AppAck` was never produced by the library on the wire, so no
+    // real data should round-trip through this variant.
+    #[doc(hidden)]
+    #[serde(rename = "AppAck")]
+    _AppAck,
     SelfRemove,
+    Custom(u16),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    Grease(u16),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral,
     #[cfg(feature = "extensions-draft-08")]
     AppDataUpdate,
-    Grease(u16),
-    Custom(u16),
 }
 
 impl ProposalType {
@@ -103,7 +116,10 @@ impl ProposalType {
             | ProposalType::Reinit
             | ProposalType::ExternalInit
             | ProposalType::GroupContextExtensions => true,
-            ProposalType::SelfRemove | ProposalType::Grease(_) | ProposalType::Custom(_) => false,
+            ProposalType::SelfRemove
+            | ProposalType::Grease(_)
+            | ProposalType::Custom(_)
+            | ProposalType::_AppAck => false,
             #[cfg(feature = "extensions-draft-08")]
             ProposalType::AppEphemeral | ProposalType::AppDataUpdate => false,
         }
@@ -206,6 +222,7 @@ impl From<ProposalType> for u16 {
             #[cfg(feature = "extensions-draft-08")]
             ProposalType::AppEphemeral => 0x0009,
             ProposalType::SelfRemove => 0x000a,
+            ProposalType::_AppAck => 0x000b,
             ProposalType::Grease(id) => id,
             ProposalType::Custom(id) => id,
         }
@@ -231,6 +248,9 @@ impl From<ProposalType> for u16 {
 ///     };
 /// } Proposal;
 /// ```
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 #[repr(u16)]
@@ -242,14 +262,24 @@ pub enum Proposal {
     ReInit(Box<ReInitProposal>),
     ExternalInit(Box<ExternalInitProposal>),
     GroupContextExtensions(Box<GroupContextExtensionProposal>),
-    // # Extensions
-    #[cfg(feature = "extensions-draft-08")]
-    AppDataUpdate(Box<AppDataUpdateProposal>),
+    // Placeholder for the removed `AppAck(Box<AppAckProposal>)` variant. Kept
+    // (hidden) to preserve the serde variant indices of subsequent variants
+    // for non-self-describing formats. The library never produced `AppAck`
+    // proposals, so no real persisted data should round-trip through this
+    // variant; constructing it directly is unsupported.
+    #[doc(hidden)]
+    #[serde(rename = "AppAck")]
+    _AppAck,
     // A SelfRemove proposal is an empty struct.
     SelfRemove,
+    Custom(Box<CustomProposal>),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataUpdate(Box<AppDataUpdateProposal>),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral(Box<AppEphemeralProposal>),
-    Custom(Box<CustomProposal>),
 }
 
 impl Proposal {
@@ -304,12 +334,13 @@ impl Proposal {
             Proposal::ReInit(_) => ProposalType::Reinit,
             Proposal::ExternalInit(_) => ProposalType::ExternalInit,
             Proposal::GroupContextExtensions(_) => ProposalType::GroupContextExtensions,
+            Proposal::_AppAck => ProposalType::_AppAck,
+            Proposal::SelfRemove => ProposalType::SelfRemove,
+            Proposal::Custom(custom) => ProposalType::Custom(custom.proposal_type.to_owned()),
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppDataUpdate(_) => ProposalType::AppDataUpdate,
-            Proposal::SelfRemove => ProposalType::SelfRemove,
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(_) => ProposalType::AppEphemeral,
-            Proposal::Custom(custom) => ProposalType::Custom(custom.proposal_type.to_owned()),
         }
     }
 

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -1274,7 +1274,7 @@ impl CustomProposal {
 mod tests {
     use tls_codec::{Deserialize, Serialize};
 
-    use super::ProposalType;
+    use super::*;
 
     #[test]
     fn that_unknown_proposal_types_are_de_serialized_correctly() {
@@ -1299,5 +1299,100 @@ mod tests {
             let got_serialized = got.tls_serialize_detached().unwrap();
             assert_eq!(test, got_serialized);
         }
+    }
+
+    /// Locks the `(variant_index, variant_name)` pair that the manual
+    /// `Serialize` impl for [`ProposalType`] emits for each variant. These
+    /// values are the bincode/postcard wire encoding of the enum tag and must
+    /// not change without a deliberate, versioned migration of every existing
+    /// persisted group.
+    ///
+    /// When adding a new variant, append a new `check(...)` line with a fresh
+    /// `variant_index` — never reuse or renumber the existing entries.
+    #[test]
+    fn proposal_type_variant_indices() {
+        use crate::utils::variant_index_probe::probe;
+
+        fn check(value: ProposalType, expected_index: u32, expected_name: &'static str) {
+            let (idx, name) =
+                probe(&value).expect("ProposalType Serialize should call serialize_*_variant");
+            assert_eq!(
+                (idx, name),
+                (expected_index, expected_name),
+                "ProposalType::{expected_name} drifted from index {expected_index}",
+            );
+        }
+
+        check(ProposalType::Add, 0, "Add");
+        check(ProposalType::Update, 1, "Update");
+        check(ProposalType::Remove, 2, "Remove");
+        check(ProposalType::PreSharedKey, 3, "PreSharedKey");
+        check(ProposalType::Reinit, 4, "Reinit");
+        check(ProposalType::ExternalInit, 5, "ExternalInit");
+        check(
+            ProposalType::GroupContextExtensions,
+            6,
+            "GroupContextExtensions",
+        );
+        check(ProposalType::_AppAck, 7, "AppAck");
+        check(ProposalType::SelfRemove, 8, "SelfRemove");
+        check(ProposalType::Custom(0), 9, "Custom");
+        check(ProposalType::Grease(0), 10, "Grease");
+        #[cfg(feature = "extensions-draft-08")]
+        check(ProposalType::AppEphemeral, 11, "AppEphemeral");
+        #[cfg(feature = "extensions-draft-08")]
+        check(ProposalType::AppDataUpdate, 12, "AppDataUpdate");
+    }
+
+    /// Locks the `(variant_index, variant_name)` pair that the manual
+    /// `Serialize` impl for [`Proposal`] emits for each variant. See
+    /// [`proposal_type_variant_indices`] for the rationale.
+    ///
+    /// Variants whose payload is non-trivial to construct in a unit-test
+    /// context (those carrying `Box<…Proposal>` with cryptographic content)
+    /// are exercised indirectly via the [`ProposalType`] test: the
+    /// `Serialize` impls for `Proposal` and `ProposalType` use the same
+    /// numeric indices by construction, and the `Proposal::proposal_type()`
+    /// match keeps the two enums in lockstep. The variants exercised
+    /// directly here are the ones that historically drifted in PRs since
+    /// openmls-0.7.x (`_AppAck`, `SelfRemove`, `Custom`).
+    #[test]
+    fn proposal_variant_indices_anchor_variants() {
+        use crate::utils::variant_index_probe::probe;
+
+        fn check(value: Proposal, expected_index: u32, expected_name: &'static str) {
+            let (idx, name) =
+                probe(&value).expect("Proposal Serialize should call serialize_*_variant");
+            assert_eq!(
+                (idx, name),
+                (expected_index, expected_name),
+                "Proposal::{expected_name} drifted from index {expected_index}",
+            );
+        }
+
+        // Variants with payloads that are cheap to construct from primitives.
+        check(
+            Proposal::Remove(Box::new(RemoveProposal {
+                removed: crate::binary_tree::array_representation::LeafNodeIndex::new(0),
+            })),
+            2,
+            "Remove",
+        );
+        check(
+            Proposal::ExternalInit(Box::new(ExternalInitProposal::from(Vec::<u8>::new()))),
+            5,
+            "ExternalInit",
+        );
+
+        // Placeholders / unit variants — the historical drift points.
+        check(Proposal::_AppAck, 7, "AppAck");
+        check(Proposal::SelfRemove, 8, "SelfRemove");
+
+        // Custom — was at index 9 in 0.7.x and must remain there.
+        check(
+            Proposal::Custom(Box::new(CustomProposal::new(0x7C7C, Vec::new()))),
+            9,
+            "Custom",
+        );
     }
 }

--- a/openmls/src/messages/proposals_in.rs
+++ b/openmls/src/messages/proposals_in.rs
@@ -425,6 +425,9 @@ impl From<crate::messages::proposals::Proposal> for ProposalIn {
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(app_ephemeral) => Self::AppEphemeral(app_ephemeral),
             Proposal::Custom(other) => Self::Custom(other),
+            // Hidden placeholder kept only for serde wire-format stability;
+            // the library does not produce this variant.
+            Proposal::_AppAck => Self::SelfRemove,
         }
     }
 }

--- a/openmls/src/schedule/message_secrets.rs
+++ b/openmls/src/schedule/message_secrets.rs
@@ -1,5 +1,10 @@
 //! This module defines the [`MessageSecrets`] struct that can be used for message decryption & verification
 
+#[cfg(target_arch = "wasm32")]
+use web_time::SystemTime;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::SystemTime;
+
 use super::*;
 
 /// Combined message secrets that need to be stored for later decryption/verification
@@ -16,7 +21,7 @@ pub(crate) struct MessageSecrets {
     /// `None` if no timestamp is available
     /// NOTE: SystemTime is not guaranteed to be monotonic.
     #[serde(default)]
-    added_at: Option<std::time::SystemTime>,
+    added_at: Option<SystemTime>,
 }
 
 #[cfg(not(feature = "crypto-debug"))]
@@ -77,13 +82,13 @@ impl MessageSecrets {
         &mut self.secret_tree
     }
 
-    pub(crate) fn timestamp(&self) -> Option<std::time::SystemTime> {
+    pub(crate) fn timestamp(&self) -> Option<SystemTime> {
         self.added_at
     }
 
     pub(crate) fn with_timestamp(
         self,
-        timestamp: impl Into<Option<std::time::SystemTime>>,
+        timestamp: impl Into<Option<SystemTime>>,
     ) -> Self {
         Self {
             added_at: timestamp.into(),

--- a/openmls/src/schedule/message_secrets.rs
+++ b/openmls/src/schedule/message_secrets.rs
@@ -8,7 +8,28 @@ use std::time::SystemTime;
 use super::*;
 
 /// Combined message secrets that need to be stored for later decryption/verification
-#[derive(Serialize, Deserialize)]
+//
+// IMPORTANT: this struct is part of the persisted on-disk format (it lives
+// inside `MessageSecretsStore`, which is written by the storage provider).
+// The first five fields are the openmls-0.7.x shape and MUST NOT be reordered
+// or have fields inserted between them. The trailing `added_at` field is
+// always serialized but is deserialized *tolerantly*: a custom
+// `Deserialize` impl probes for the field via `SeqAccess::next_element` and
+// treats any error (e.g. bincode EOF past the 0.7.x five-field boundary) as
+// "field absent, default to `None`". This lets the same struct round-trip:
+//
+// * post-0.8 data that already contains the field (any format),
+// * 0.7.x data that predates the field, in both self-describing formats
+//   (JSON, CBOR — via `#[serde(default)]` semantics on the map path) and
+//   non-self-describing formats (bincode, postcard — via the EOF-tolerant
+//   seq path).
+//
+// Caveat for non-self-describing formats: this struct must be the **last
+// field** of any containing struct for the EOF-tolerant fallback to work
+// safely. In `MessageSecretsStore` that is the case. Within `EpochTree`,
+// `MessageSecrets` precedes `leaves`, so 0.7.x EpochTree bytes (which lack
+// `added_at`) cannot be read tolerantly here — the deserializer would
+// interpret leaves-length bytes as the `Option<SystemTime>` tag.
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecrets {
@@ -17,11 +38,172 @@ pub(crate) struct MessageSecrets {
     confirmation_key: ConfirmationKey,
     serialized_context: Vec<u8>,
     secret_tree: SecretTree,
-    /// When the secrets were added to the store
-    /// `None` if no timestamp is available
+    /// When the secrets were added to the store.
+    ///
+    /// `None` if no timestamp is available — including when reading data
+    /// that predates this field (see the struct-level doc comment for the
+    /// tolerant-deserialization rules).
+    ///
     /// NOTE: SystemTime is not guaranteed to be monotonic.
-    #[serde(default)]
     added_at: Option<SystemTime>,
+}
+
+const MESSAGE_SECRETS_FIELDS: &[&str] = &[
+    "sender_data_secret",
+    "membership_key",
+    "confirmation_key",
+    "serialized_context",
+    "secret_tree",
+    "added_at",
+];
+
+impl Serialize for MessageSecrets {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut s = serializer.serialize_struct("MessageSecrets", MESSAGE_SECRETS_FIELDS.len())?;
+        s.serialize_field("sender_data_secret", &self.sender_data_secret)?;
+        s.serialize_field("membership_key", &self.membership_key)?;
+        s.serialize_field("confirmation_key", &self.confirmation_key)?;
+        s.serialize_field("serialized_context", &self.serialized_context)?;
+        s.serialize_field("secret_tree", &self.secret_tree)?;
+        s.serialize_field("added_at", &self.added_at)?;
+        s.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for MessageSecrets {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_struct(
+            "MessageSecrets",
+            MESSAGE_SECRETS_FIELDS,
+            MessageSecretsVisitor,
+        )
+    }
+}
+
+struct MessageSecretsVisitor;
+
+impl<'de> serde::de::Visitor<'de> for MessageSecretsVisitor {
+    type Value = MessageSecrets;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("struct MessageSecrets")
+    }
+
+    fn visit_seq<A: serde::de::SeqAccess<'de>>(
+        self,
+        mut seq: A,
+    ) -> Result<MessageSecrets, A::Error> {
+        use serde::de::Error;
+
+        let sender_data_secret = seq
+            .next_element::<SenderDataSecret>()?
+            .ok_or_else(|| Error::missing_field("sender_data_secret"))?;
+        let membership_key = seq
+            .next_element::<MembershipKey>()?
+            .ok_or_else(|| Error::missing_field("membership_key"))?;
+        let confirmation_key = seq
+            .next_element::<ConfirmationKey>()?
+            .ok_or_else(|| Error::missing_field("confirmation_key"))?;
+        let serialized_context = seq
+            .next_element::<Vec<u8>>()?
+            .ok_or_else(|| Error::missing_field("serialized_context"))?;
+        let secret_tree = seq
+            .next_element::<SecretTree>()?
+            .ok_or_else(|| Error::missing_field("secret_tree"))?;
+
+        // Tolerant tail read: post-0.8 data has a sixth field
+        // `added_at: Option<SystemTime>`. 0.7.x data does not. Any failure
+        // here — `Ok(None)` from self-describing formats, EOF from bincode
+        // and friends — is treated as "field absent" and defaults to `None`.
+        // See the struct-level comment for the safety constraint that
+        // requires this to be the last field of any containing struct.
+        let added_at = seq
+            .next_element::<Option<SystemTime>>()
+            .unwrap_or(None)
+            .flatten();
+
+        Ok(MessageSecrets {
+            sender_data_secret,
+            membership_key,
+            confirmation_key,
+            serialized_context,
+            secret_tree,
+            added_at,
+        })
+    }
+
+    fn visit_map<A: serde::de::MapAccess<'de>>(
+        self,
+        mut map: A,
+    ) -> Result<MessageSecrets, A::Error> {
+        use serde::de::Error;
+
+        let mut sender_data_secret: Option<SenderDataSecret> = None;
+        let mut membership_key: Option<MembershipKey> = None;
+        let mut confirmation_key: Option<ConfirmationKey> = None;
+        let mut serialized_context: Option<Vec<u8>> = None;
+        let mut secret_tree: Option<SecretTree> = None;
+        let mut added_at: Option<Option<SystemTime>> = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "sender_data_secret" => {
+                    if sender_data_secret.is_some() {
+                        return Err(Error::duplicate_field("sender_data_secret"));
+                    }
+                    sender_data_secret = Some(map.next_value()?);
+                }
+                "membership_key" => {
+                    if membership_key.is_some() {
+                        return Err(Error::duplicate_field("membership_key"));
+                    }
+                    membership_key = Some(map.next_value()?);
+                }
+                "confirmation_key" => {
+                    if confirmation_key.is_some() {
+                        return Err(Error::duplicate_field("confirmation_key"));
+                    }
+                    confirmation_key = Some(map.next_value()?);
+                }
+                "serialized_context" => {
+                    if serialized_context.is_some() {
+                        return Err(Error::duplicate_field("serialized_context"));
+                    }
+                    serialized_context = Some(map.next_value()?);
+                }
+                "secret_tree" => {
+                    if secret_tree.is_some() {
+                        return Err(Error::duplicate_field("secret_tree"));
+                    }
+                    secret_tree = Some(map.next_value()?);
+                }
+                "added_at" => {
+                    if added_at.is_some() {
+                        return Err(Error::duplicate_field("added_at"));
+                    }
+                    added_at = Some(map.next_value()?);
+                }
+                _ => {
+                    // Ignore unknown fields for forward compatibility.
+                    let _: serde::de::IgnoredAny = map.next_value()?;
+                }
+            }
+        }
+
+        Ok(MessageSecrets {
+            sender_data_secret: sender_data_secret
+                .ok_or_else(|| Error::missing_field("sender_data_secret"))?,
+            membership_key: membership_key.ok_or_else(|| Error::missing_field("membership_key"))?,
+            confirmation_key: confirmation_key
+                .ok_or_else(|| Error::missing_field("confirmation_key"))?,
+            serialized_context: serialized_context
+                .ok_or_else(|| Error::missing_field("serialized_context"))?,
+            secret_tree: secret_tree.ok_or_else(|| Error::missing_field("secret_tree"))?,
+            added_at: added_at.unwrap_or(None),
+        })
+    }
 }
 
 #[cfg(not(feature = "crypto-debug"))]

--- a/openmls/src/schedule/message_secrets.rs
+++ b/openmls/src/schedule/message_secrets.rs
@@ -11,25 +11,18 @@ use super::*;
 //
 // IMPORTANT: this struct is part of the persisted on-disk format (it lives
 // inside `MessageSecretsStore`, which is written by the storage provider).
-// The first five fields are the openmls-0.7.x shape and MUST NOT be reordered
-// or have fields inserted between them. The trailing `added_at` field is
-// always serialized but is deserialized *tolerantly*: a custom
-// `Deserialize` impl probes for the field via `SeqAccess::next_element` and
-// treats any error (e.g. bincode EOF past the 0.7.x five-field boundary) as
-// "field absent, default to `None`". This lets the same struct round-trip:
+// The five serialized fields are the openmls-0.7.x shape and MUST NOT be
+// reordered or have fields inserted between them — the wire format is
+// `bincode`/`postcard` positional encoding and any change breaks all stored
+// state.
 //
-// * post-0.8 data that already contains the field (any format),
-// * 0.7.x data that predates the field, in both self-describing formats
-//   (JSON, CBOR — via `#[serde(default)]` semantics on the map path) and
-//   non-self-describing formats (bincode, postcard — via the EOF-tolerant
-//   seq path).
-//
-// Caveat for non-self-describing formats: this struct must be the **last
-// field** of any containing struct for the EOF-tolerant fallback to work
-// safely. In `MessageSecretsStore` that is the case. Within `EpochTree`,
-// `MessageSecrets` precedes `leaves`, so 0.7.x EpochTree bytes (which lack
-// `added_at`) cannot be read tolerantly here — the deserializer would
-// interpret leaves-length bytes as the `Option<SystemTime>` tag.
+// The `added_at` timestamp is a fork-only extension. It is NOT serialized as
+// part of `MessageSecrets` itself (doing so would corrupt the byte stream of
+// any containing struct that has fields after `message_secrets`). Instead it
+// is carried as a trailing, tolerantly-deserialized field on the *containing*
+// structs (`EpochTree` and `MessageSecretsStore`) and re-hydrated back onto
+// the `MessageSecrets` during deserialization. See `past_secrets.rs`.
+#[derive(Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecrets {
@@ -41,168 +34,24 @@ pub(crate) struct MessageSecrets {
     /// When the secrets were added to the store.
     ///
     /// `None` if no timestamp is available — including when reading data
-    /// that predates this field (see the struct-level doc comment for the
-    /// tolerant-deserialization rules).
+    /// that predates this field.
+    ///
+    /// Skipped during serde: persisted out-of-band as a trailing optional
+    /// field on the containing struct (see module-level doc).
     ///
     /// NOTE: SystemTime is not guaranteed to be monotonic.
-    added_at: Option<SystemTime>,
+    #[serde(skip)]
+    pub(crate) added_at: Option<SystemTime>,
 }
 
-const MESSAGE_SECRETS_FIELDS: &[&str] = &[
-    "sender_data_secret",
-    "membership_key",
-    "confirmation_key",
-    "serialized_context",
-    "secret_tree",
-    "added_at",
-];
-
-impl Serialize for MessageSecrets {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeStruct;
-
-        let mut s = serializer.serialize_struct("MessageSecrets", MESSAGE_SECRETS_FIELDS.len())?;
-        s.serialize_field("sender_data_secret", &self.sender_data_secret)?;
-        s.serialize_field("membership_key", &self.membership_key)?;
-        s.serialize_field("confirmation_key", &self.confirmation_key)?;
-        s.serialize_field("serialized_context", &self.serialized_context)?;
-        s.serialize_field("secret_tree", &self.secret_tree)?;
-        s.serialize_field("added_at", &self.added_at)?;
-        s.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for MessageSecrets {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_struct(
-            "MessageSecrets",
-            MESSAGE_SECRETS_FIELDS,
-            MessageSecretsVisitor,
-        )
-    }
-}
-
-struct MessageSecretsVisitor;
-
-impl<'de> serde::de::Visitor<'de> for MessageSecretsVisitor {
-    type Value = MessageSecrets;
-
-    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("struct MessageSecrets")
-    }
-
-    fn visit_seq<A: serde::de::SeqAccess<'de>>(
-        self,
-        mut seq: A,
-    ) -> Result<MessageSecrets, A::Error> {
-        use serde::de::Error;
-
-        let sender_data_secret = seq
-            .next_element::<SenderDataSecret>()?
-            .ok_or_else(|| Error::missing_field("sender_data_secret"))?;
-        let membership_key = seq
-            .next_element::<MembershipKey>()?
-            .ok_or_else(|| Error::missing_field("membership_key"))?;
-        let confirmation_key = seq
-            .next_element::<ConfirmationKey>()?
-            .ok_or_else(|| Error::missing_field("confirmation_key"))?;
-        let serialized_context = seq
-            .next_element::<Vec<u8>>()?
-            .ok_or_else(|| Error::missing_field("serialized_context"))?;
-        let secret_tree = seq
-            .next_element::<SecretTree>()?
-            .ok_or_else(|| Error::missing_field("secret_tree"))?;
-
-        // Tolerant tail read: post-0.8 data has a sixth field
-        // `added_at: Option<SystemTime>`. 0.7.x data does not. Any failure
-        // here — `Ok(None)` from self-describing formats, EOF from bincode
-        // and friends — is treated as "field absent" and defaults to `None`.
-        // See the struct-level comment for the safety constraint that
-        // requires this to be the last field of any containing struct.
-        let added_at = seq
-            .next_element::<Option<SystemTime>>()
-            .unwrap_or(None)
-            .flatten();
-
-        Ok(MessageSecrets {
-            sender_data_secret,
-            membership_key,
-            confirmation_key,
-            serialized_context,
-            secret_tree,
-            added_at,
-        })
-    }
-
-    fn visit_map<A: serde::de::MapAccess<'de>>(
-        self,
-        mut map: A,
-    ) -> Result<MessageSecrets, A::Error> {
-        use serde::de::Error;
-
-        let mut sender_data_secret: Option<SenderDataSecret> = None;
-        let mut membership_key: Option<MembershipKey> = None;
-        let mut confirmation_key: Option<ConfirmationKey> = None;
-        let mut serialized_context: Option<Vec<u8>> = None;
-        let mut secret_tree: Option<SecretTree> = None;
-        let mut added_at: Option<Option<SystemTime>> = None;
-
-        while let Some(key) = map.next_key::<String>()? {
-            match key.as_str() {
-                "sender_data_secret" => {
-                    if sender_data_secret.is_some() {
-                        return Err(Error::duplicate_field("sender_data_secret"));
-                    }
-                    sender_data_secret = Some(map.next_value()?);
-                }
-                "membership_key" => {
-                    if membership_key.is_some() {
-                        return Err(Error::duplicate_field("membership_key"));
-                    }
-                    membership_key = Some(map.next_value()?);
-                }
-                "confirmation_key" => {
-                    if confirmation_key.is_some() {
-                        return Err(Error::duplicate_field("confirmation_key"));
-                    }
-                    confirmation_key = Some(map.next_value()?);
-                }
-                "serialized_context" => {
-                    if serialized_context.is_some() {
-                        return Err(Error::duplicate_field("serialized_context"));
-                    }
-                    serialized_context = Some(map.next_value()?);
-                }
-                "secret_tree" => {
-                    if secret_tree.is_some() {
-                        return Err(Error::duplicate_field("secret_tree"));
-                    }
-                    secret_tree = Some(map.next_value()?);
-                }
-                "added_at" => {
-                    if added_at.is_some() {
-                        return Err(Error::duplicate_field("added_at"));
-                    }
-                    added_at = Some(map.next_value()?);
-                }
-                _ => {
-                    // Ignore unknown fields for forward compatibility.
-                    let _: serde::de::IgnoredAny = map.next_value()?;
-                }
-            }
-        }
-
-        Ok(MessageSecrets {
-            sender_data_secret: sender_data_secret
-                .ok_or_else(|| Error::missing_field("sender_data_secret"))?,
-            membership_key: membership_key.ok_or_else(|| Error::missing_field("membership_key"))?,
-            confirmation_key: confirmation_key
-                .ok_or_else(|| Error::missing_field("confirmation_key"))?,
-            serialized_context: serialized_context
-                .ok_or_else(|| Error::missing_field("serialized_context"))?,
-            secret_tree: secret_tree.ok_or_else(|| Error::missing_field("secret_tree"))?,
-            added_at: added_at.unwrap_or(None),
-        })
+// In tests we allow comparing secrets.
+#[cfg(any(test, feature = "test-utils"))]
+impl PartialEq for MessageSecrets {
+    fn eq(&self, other: &Self) -> bool {
+        self.sender_data_secret == other.sender_data_secret
+            && self.membership_key == other.membership_key
+            && self.confirmation_key == other.confirmation_key
+            && self.secret_tree == other.secret_tree
     }
 }
 
@@ -330,16 +179,5 @@ impl MessageSecrets {
     #[cfg(any(feature = "test-utils", test))]
     pub(crate) fn replace_secret_tree(&mut self, secret_tree: SecretTree) -> SecretTree {
         std::mem::replace(&mut self.secret_tree, secret_tree)
-    }
-}
-
-// In tests we allow comparing secrets.
-#[cfg(any(test, feature = "test-utils"))]
-impl PartialEq for MessageSecrets {
-    fn eq(&self, other: &Self) -> bool {
-        self.sender_data_secret == other.sender_data_secret
-            && self.membership_key == other.membership_key
-            && self.confirmation_key == other.confirmation_key
-            && self.secret_tree == other.secret_tree
     }
 }

--- a/openmls/src/schedule/pprf/mod.rs
+++ b/openmls/src/schedule/pprf/mod.rs
@@ -100,6 +100,11 @@ pub(crate) struct Pprf<P: Prefix> {
         deserialize_with = "deserialize_hashmap"
     )]
     nodes: HashMap<P, PprfNode>, // Mapping of prefix and depth to node
+    // Serialized as `u64` so persisted application-export-tree bytes are
+    // portable between 32-bit (`wasm32`) and 64-bit hosts. The width is the
+    // tree size in *bytes* of the underlying prefix and is independent of
+    // any key derivation input.
+    #[serde(with = "crate::utils::usize_as_u64")]
     width: usize,
 }
 

--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -560,11 +560,19 @@ pub mod store {
     /// Resumption PSK store.
     ///
     /// This is where the resumption PSKs are kept in a rollover list.
+    //
+    // `max_number_of_secrets` and `cursor` are serialized through the
+    // `usize_as_u64` adapter so bytes are portable between 32-bit
+    // (`wasm32`) and 64-bit hosts. Neither value feeds into key derivation —
+    // `cursor` is a ring-buffer index and `max_number_of_secrets` is the
+    // cap — so the only correctness requirement is that they round-trip.
     #[derive(Debug, Serialize, Deserialize)]
     #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
     pub(crate) struct ResumptionPskStore {
+        #[serde(with = "crate::utils::usize_as_u64")]
         max_number_of_secrets: usize,
         resumption_psk: Vec<(GroupEpoch, ResumptionPskSecret)>,
+        #[serde(with = "crate::utils::usize_as_u64")]
         cursor: usize,
     }
 

--- a/openmls/src/utils.rs
+++ b/openmls/src/utils.rs
@@ -54,6 +54,29 @@ macro_rules! log_content {
     (trace, $($arg:tt)*) => {{}};
 }
 
+/// Serde helper for serializing a `usize` field as a fixed-width `u64`.
+///
+/// `usize` is 32 bits on `wasm32` and 64 bits on most host targets. The
+/// derived `Serialize`/`Deserialize` for `usize` writes a platform-native
+/// width, which makes persisted bytes non-portable across builds.
+///
+/// Fields that participate in the storage format should opt into this helper
+/// via `#[serde(with = "crate::utils::usize_as_u64")]` so the wire shape is
+/// always 8 bytes for non-self-describing formats and an unambiguous JSON
+/// number for self-describing formats.
+pub(crate) mod usize_as_u64 {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &usize, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(*value as u64)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<usize, D::Error> {
+        let value = u64::deserialize(deserializer)?;
+        usize::try_from(value).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Helper mod that converts a objects that implement FromIterator<_,_> (like a
 /// HashMap or a BTreeMap) into a vector of tuples and vice versa.
 pub mod vector_converter {

--- a/openmls/src/utils.rs
+++ b/openmls/src/utils.rs
@@ -77,6 +77,220 @@ pub(crate) mod usize_as_u64 {
     }
 }
 
+/// Test-only `serde::Serializer` that captures the `(variant_index, variant)`
+/// arguments of a `serialize_*_variant` call and returns them as the serializer
+/// `Ok` value. Used by per-enum tests to pin the bincode/postcard wire
+/// indices of persisted enums (`CredentialType`, `ExtensionType`, `Extension`,
+/// `ProposalType`, `Proposal`).
+///
+/// Every other `Serializer` method returns an error: the probe is intentionally
+/// minimal and is only meant to be driven against enum variants. Payloads of
+/// newtype / tuple variants are accepted but never recursed into, so payload
+/// types do not need to be cheaply constructible for the probe to work.
+#[cfg(test)]
+pub(crate) mod variant_index_probe {
+    use core::fmt;
+    use serde::ser::{Impossible, SerializeTupleVariant};
+    use serde::{ser, Serialize, Serializer};
+
+    pub(crate) type Captured = (u32, &'static str);
+
+    /// Serialize `value` through the probe and return the
+    /// `(variant_index, variant_name)` of the variant call it issued.
+    pub(crate) fn probe<T: Serialize>(value: &T) -> Result<Captured, ProbeError> {
+        value.serialize(IndexProbe)
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct ProbeError(pub(crate) String);
+
+    impl fmt::Display for ProbeError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    impl std::error::Error for ProbeError {}
+
+    impl ser::Error for ProbeError {
+        fn custom<T: fmt::Display>(msg: T) -> Self {
+            ProbeError(msg.to_string())
+        }
+    }
+
+    pub(crate) struct IndexProbe;
+
+    fn reject<T>(method: &'static str) -> Result<T, ProbeError> {
+        Err(ProbeError(format!(
+            "IndexProbe::{method} unexpectedly called"
+        )))
+    }
+
+    impl Serializer for IndexProbe {
+        type Ok = Captured;
+        type Error = ProbeError;
+        type SerializeSeq = Impossible<Captured, ProbeError>;
+        type SerializeTuple = Impossible<Captured, ProbeError>;
+        type SerializeTupleStruct = Impossible<Captured, ProbeError>;
+        type SerializeTupleVariant = TupleVariantCapture;
+        type SerializeMap = Impossible<Captured, ProbeError>;
+        type SerializeStruct = Impossible<Captured, ProbeError>;
+        type SerializeStructVariant = Impossible<Captured, ProbeError>;
+
+        fn serialize_unit_variant(
+            self,
+            _name: &'static str,
+            variant_index: u32,
+            variant: &'static str,
+        ) -> Result<Self::Ok, Self::Error> {
+            Ok((variant_index, variant))
+        }
+
+        fn serialize_newtype_variant<T: ?Sized + Serialize>(
+            self,
+            _name: &'static str,
+            variant_index: u32,
+            variant: &'static str,
+            _value: &T,
+        ) -> Result<Self::Ok, Self::Error> {
+            Ok((variant_index, variant))
+        }
+
+        fn serialize_tuple_variant(
+            self,
+            _name: &'static str,
+            variant_index: u32,
+            variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+            Ok(TupleVariantCapture {
+                captured: (variant_index, variant),
+            })
+        }
+
+        // Every other Serializer method is unexpected for the probe's use
+        // case (variant-index assertion on `serde`-derived enum
+        // serialization). Stub them out with an error so a misuse fails the
+        // test loudly rather than silently producing a bogus result.
+        fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_bool")
+        }
+        fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_i8")
+        }
+        fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_i16")
+        }
+        fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_i32")
+        }
+        fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_i64")
+        }
+        fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_u8")
+        }
+        fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_u16")
+        }
+        fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_u32")
+        }
+        fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_u64")
+        }
+        fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_f32")
+        }
+        fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_f64")
+        }
+        fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_char")
+        }
+        fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_str")
+        }
+        fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_bytes")
+        }
+        fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_none")
+        }
+        fn serialize_some<T: ?Sized + Serialize>(
+            self,
+            _value: &T,
+        ) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_some")
+        }
+        fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_unit")
+        }
+        fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_unit_struct")
+        }
+        fn serialize_newtype_struct<T: ?Sized + Serialize>(
+            self,
+            _name: &'static str,
+            _value: &T,
+        ) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_newtype_struct")
+        }
+        fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+            reject("serialize_seq")
+        }
+        fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+            reject("serialize_tuple")
+        }
+        fn serialize_tuple_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+            reject("serialize_tuple_struct")
+        }
+        fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+            reject("serialize_map")
+        }
+        fn serialize_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStruct, Self::Error> {
+            reject("serialize_struct")
+        }
+        fn serialize_struct_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            _variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStructVariant, Self::Error> {
+            reject("serialize_struct_variant")
+        }
+    }
+
+    pub(crate) struct TupleVariantCapture {
+        captured: Captured,
+    }
+
+    impl SerializeTupleVariant for TupleVariantCapture {
+        type Ok = Captured;
+        type Error = ProbeError;
+
+        fn serialize_field<T: ?Sized + Serialize>(
+            &mut self,
+            _value: &T,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(self.captured)
+        }
+    }
+}
+
 /// Helper mod that converts a objects that implement FromIterator<_,_> (like a
 /// HashMap or a BTreeMap) into a vector of tuples and vice versa.
 pub mod vector_converter {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix bincode/serde wire format stability for proposals, extensions, credentials, and usize fields
- Replaces auto-derived `Serialize`/`Deserialize` on `Proposal`, `ProposalType`, `Extension`, `ExtensionType`, and `CredentialType` with manual impls that use fixed variant indices and names, stabilizing the bincode/postcard wire format.
- Adds a hidden `_AppAck` placeholder variant to `Proposal` and `ProposalType` to preserve serde variant index ordering without exposing the type publicly; TLS codec handles it with explicit error or no-op arms.
- Serializes `usize` fields (`padding_size`, `number_of_resumption_psks`, `cursor`, `width`) as `u64` via a new `usize_as_u64` serde helper in [`utils.rs`](https://github.com/xmtp/openmls/pull/54/files#diff-ab64ac468d52cb0bbc2e4200813263874fc1e292889d88adde6c097b251b0273) for cross-arch portability.
- Fixes `PastEpochDeletionPolicy` to serialize `KeepAll` as `u64::MAX` and `MaxEpochs` as `u64`, replacing the previous platform-dependent `usize` encoding.
- Replaces `fluvio-wasm-timer` with `web-time` (with serde support) for wasm32 `SystemTime` usage across the codebase.
- Moves `MessageSecrets.added_at` out of the derived serde layout; `MessageSecretsStore` gains a custom tolerant serde impl that appends timestamps as trailing fields, remaining backward-compatible with older serialized data.
- Risk: existing persisted data serialized with the old auto-derived enum layouts for `Proposal`, `Extension`, or `CredentialType` will not deserialize correctly with the new fixed-index format.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e125674.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->