### PR TITLE
Restore the fork's persisted storage format on top of upstream main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2531,7 @@ version = "0.8.1"
 dependencies = [
  "backtrace",
  "base64",
+ "bincode",
  "clap",
  "criterion",
  "flate2",

--- a/compat_tests/Cargo.toml
+++ b/compat_tests/Cargo.toml
@@ -12,6 +12,10 @@ compat_0_8_1_extensions = [
     "openmls_0_8_1/extensions-draft-08",
     "openmls/extensions-draft",
 ]
+# Exercises the fork storage-tag baseline (`test_fork_storage_tags.rs`) on the
+# `storage_tag` path with `extensions-draft` on, so `AppDataDictionary`'s tag is
+# covered without pulling in `0-8-1-storage-format`.
+fork-baseline = ["openmls/extensions-draft"]
 
 [dependencies]
 serde = { version = "^1.0" }

--- a/compat_tests/test.sh
+++ b/compat_tests/test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 cargo test -F compat_0_7_1
 cargo test -F compat_0_8_1
 cargo test -F compat_0_8_1_extensions
+# Fork storage-tag baseline (extensions-draft, storage_tag path).
+cargo test -F fork-baseline

--- a/compat_tests/tests/test_fork_storage_tags.rs
+++ b/compat_tests/tests/test_fork_storage_tags.rs
@@ -1,0 +1,69 @@
+//! Fork-owned storage-tag baseline.
+//!
+//! Upstream's `test_storage_tag_stability` pins our enums against *published*
+//! openmls releases. The XMTP fork intentionally diverges on the persisted
+//! `storage_tag` numbering of `ExtensionType` / `Extension`: `ImmutableMetadata`
+//! occupies tag 6, which shifts `Unknown` / `Grease` / `AppDataDictionary` up by
+//! one, so the fork keeps reading groups persisted by older fork releases. That
+//! layout can never match a published crate, so rather than comparing against
+//! one we pin the fork's numbering positively here.
+//!
+//! Only meaningful on the `storage_tag` path — the format libxmtp actually
+//! persists. `compat_0_7_1` and `fork-baseline` build our `openmls` without
+//! `0-8-1-storage-format`, so they exercise the `storage_tag` derive; the
+//! `compat_0_8_1*` features build it positionally, which the upstream suite
+//! already covers. (`0-8-1-storage-format` is an `openmls` feature, not one of
+//! ours, so it cannot be named in a `cfg` here — we gate on our own features
+//! that select the path instead.)
+#![cfg(any(feature = "compat_0_7_1", feature = "fork-baseline"))]
+
+use openmls::extensions::{Extension, ExtensionType, Metadata, UnknownExtension};
+use openmls_compat_tests::storage_tag_check::StorageTags;
+
+/// The `(variant_index, variant_name)` a value serializes to. `variant_index`
+/// is the bincode/postcard wire tag; `variant_name` is the JSON/CBOR tag.
+#[track_caller]
+fn tag<T: serde::Serialize>(value: &T) -> (u32, &'static str) {
+    let t = StorageTags::for_enum_variant(value).expect("value is an enum variant");
+    (t.non_self_describing, t.self_describing)
+}
+
+#[test]
+fn extension_type_fork_storage_tags() {
+    // Tags 0-5 are shared with upstream and unchanged by the fork.
+    assert_eq!(tag(&ExtensionType::ApplicationId), (0, "ApplicationId"));
+    assert_eq!(tag(&ExtensionType::RatchetTree), (1, "RatchetTree"));
+    assert_eq!(
+        tag(&ExtensionType::RequiredCapabilities),
+        (2, "RequiredCapabilities")
+    );
+    assert_eq!(tag(&ExtensionType::ExternalPub), (3, "ExternalPub"));
+    assert_eq!(tag(&ExtensionType::ExternalSenders), (4, "ExternalSenders"));
+    assert_eq!(tag(&ExtensionType::LastResort), (5, "LastResort"));
+    // Fork divergence: ImmutableMetadata claims 6, pushing the rest up one.
+    assert_eq!(
+        tag(&ExtensionType::ImmutableMetadata),
+        (6, "ImmutableMetadata")
+    );
+    assert_eq!(tag(&ExtensionType::Unknown(20)), (7, "Unknown"));
+    assert_eq!(tag(&ExtensionType::Grease(0)), (8, "Grease"));
+    #[cfg(feature = "fork-baseline")]
+    assert_eq!(
+        tag(&ExtensionType::AppDataDictionary),
+        (9, "AppDataDictionary")
+    );
+}
+
+#[test]
+fn extension_fork_storage_tags() {
+    // Same divergence on the payload-carrying `Extension` enum. Payload contents
+    // are irrelevant to the tag probe; use the cheapest value for each variant.
+    assert_eq!(
+        tag(&Extension::ImmutableMetadata(Metadata::new(Vec::new()))),
+        (6, "ImmutableMetadata")
+    );
+    assert_eq!(
+        tag(&Extension::Unknown(20, UnknownExtension(Vec::new()))),
+        (7, "Unknown")
+    );
+}

--- a/compat_tests/tests/test_storage_tag_stability.rs
+++ b/compat_tests/tests/test_storage_tag_stability.rs
@@ -1,5 +1,10 @@
 //! These tests check storage tag stability for `serde` serializations of `Extension`,
 //!   `ExtensionType`, `Proposal`, `ProposalType`, and `CredentialType`.
+//!
+//! This file compares against published openmls crates; it is inert unless a
+//! `compat_*` feature is on (the `fork-baseline` feature exercises only
+//! `test_fork_storage_tags.rs`).
+#![cfg(any(feature = "compat_0_7_1", feature = "compat_0_8_1"))]
 #![allow(dead_code)]
 
 use openmls_compat_tests::storage_tag_check::*;
@@ -112,6 +117,14 @@ macro_rules! compat_tests {
         mod $mod_name {
             use super::*;
 
+            // The XMTP fork's `storage_tag` numbering for `ExtensionType` /
+            // `Extension` diverges from published openmls (`ImmutableMetadata`
+            // takes tag 6, shifting the rest up), so this comparison against a
+            // published crate only holds on the positional `compat_0_8_1*` runs
+            // (which build our `openmls` with `0-8-1-storage-format`). On the
+            // `storage_tag` path (`compat_0_7_1`) the fork's numbering is pinned
+            // positively by `test_fork_storage_tags.rs` instead.
+            #[cfg(feature = "compat_0_8_1")]
             generate_test_fn!(
                 test_extension_type,
                 $before::prelude::ExtensionType,
@@ -119,6 +132,7 @@ macro_rules! compat_tests {
                 TestData::load().extension_type,
                 $version
             );
+            #[cfg(feature = "compat_0_8_1")]
             generate_test_fn!(
                 test_extension,
                 $before::prelude::Extension,

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -170,6 +170,10 @@ wasm-bindgen = "0.2.100"
 wasm-bindgen-test = "0.3.50"
 clap = { version = "4", features = ["derive"] }
 base64 = "0.22.1"
+# Non-self-describing codec used to guard `PastEpochDeletionPolicy` against a
+# regression to `#[serde(untagged)]`, which fails under such formats (the shape
+# libxmtp persists with). Matches libxmtp's bincode 1.x.
+bincode = "1.3"
 flate2 = "1.0"
 indicatif = "0.18.3"
 

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -132,22 +132,22 @@ pub enum ExtensionType {
     LastResort,
 
     #[cfg(feature = "extensions-draft")]
-    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 8)]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 9)]
     /// AppDataDictionary extension
     AppDataDictionary,
 
-    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 7)]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 8)]
     /// A GREASE extension type for ensuring extensibility.
     Grease(u16),
 
-    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 6)]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 7)]
     /// A currently unknown extension type.
     Unknown(u16),
 
     // Declared last so the `0-8-1-storage-format` positional index does not
     // shift the shared upstream variants; the persisted tag is set by
     // `storage_tag`, independent of declaration order.
-    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 9)]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 6)]
     /// Immutable metadata extension for the GroupContext.
     /// This can only be set on creation of the group.
     ImmutableMetadata,
@@ -378,7 +378,7 @@ pub enum Extension {
     /// An [`ExternalSendersExtension`]
     ExternalSenders(ExternalSendersExtension),
 
-    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 7)]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 8)]
     /// An [`AppDataDictionaryExtension`]
     #[cfg(feature = "extensions-draft")]
     AppDataDictionary(AppDataDictionaryExtension),
@@ -387,14 +387,14 @@ pub enum Extension {
     /// A [`LastResortExtension`]
     LastResort(LastResortExtension),
 
-    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 6)]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 7)]
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
 
     // Declared last so the `0-8-1-storage-format` positional index does not
     // shift the shared upstream variants; the persisted tag is set by
     // `storage_tag`, independent of declaration order.
-    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 8)]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 6)]
     /// An immutable [`Metadata`] extension
     ImmutableMetadata(Metadata),
 }

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -76,38 +76,36 @@ impl Serialize for PastEpochDeletionPolicy {
     where
         S: serde::Serializer,
     {
-        let usize = match self {
-            Self::MaxEpochs(epochs) => *epochs,
-            Self::KeepAll => usize::MAX,
+        // Wire encoding is always `u64` (never platform-dependent `usize`) so
+        // bytes written on a 64-bit host stay readable on `wasm32` and vice
+        // versa. `KeepAll` is encoded as `u64::MAX` rather than `usize::MAX as
+        // u64`, because `usize::MAX` differs between platforms (`u32::MAX` on
+        // `wasm32`, `u64::MAX` on 64-bit).
+        let value: u64 = match self {
+            Self::MaxEpochs(epochs) => *epochs as u64,
+            Self::KeepAll => u64::MAX,
         };
-        serializer.serialize_u64(usize as u64)
+        serializer.serialize_u64(value)
     }
 }
 
 impl<'de> Deserialize<'de> for PastEpochDeletionPolicy {
+    // Intentionally a plain `u64`, not upstream's `#[serde(untagged)]`
+    // `Int | Tagged` form. `untagged` buffers into a self-describing value and
+    // so requires `Deserializer::deserialize_any`; libxmtp persists this via
+    // bincode, which is non-self-describing and errors on `deserialize_any`, so
+    // the untagged form fails at runtime for every group. The fork only ever
+    // wrote the plain-integer form, so the pre-8bdba6f tagged variant is moot.
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        // Previously supported format (changed to plain integer in 8bdba6f)
-        #[derive(Deserialize)]
-        enum Tagged {
-            MaxEpochs(usize),
-            KeepAll,
+        // Check the `KeepAll` sentinel before narrowing, so a `KeepAll` written
+        // on a 64-bit host (`u64::MAX`) still loads on `wasm32`.
+        let value = u64::deserialize(deserializer)?;
+        if value == u64::MAX {
+            Ok(Self::KeepAll)
+        } else {
+            let epochs = usize::try_from(value).map_err(serde::de::Error::custom)?;
+            Ok(Self::MaxEpochs(epochs))
         }
-
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum Format {
-            Int(u64),
-            Tagged(Tagged),
-        }
-
-        Ok(match Format::deserialize(deserializer)? {
-            Format::Int(u64::MAX) => Self::KeepAll,
-            Format::Int(n) => {
-                Self::MaxEpochs(usize::try_from(n).map_err(serde::de::Error::custom)?)
-            }
-            Format::Tagged(Tagged::MaxEpochs(n)) => Self::MaxEpochs(n),
-            Format::Tagged(Tagged::KeepAll) => Self::KeepAll,
-        })
     }
 }
 
@@ -724,14 +722,23 @@ mod tests {
         assert_eq!(deserialized, PastEpochDeletionPolicy::KeepAll);
     }
 
-    #[test]
-    fn past_epoch_deletion_policy_deserializes_legacy_tagged_format() {
-        // Externally tagged enum format used before 8bdba6f.
-        let deserialized: PastEpochDeletionPolicy =
-            serde_json::from_str(r#"{"MaxEpochs":42}"#).unwrap();
-        assert_eq!(deserialized, PastEpochDeletionPolicy::MaxEpochs(42));
+    // The pre-8bdba6f externally-tagged format is intentionally unsupported: it
+    // is unrepresentable under the non-self-describing codec libxmtp persists
+    // with (see the `Deserialize` impl), and the fork never wrote it.
 
-        let deserialized: PastEpochDeletionPolicy = serde_json::from_str(r#""KeepAll""#).unwrap();
-        assert_eq!(deserialized, PastEpochDeletionPolicy::KeepAll);
+    #[test]
+    fn past_epoch_deletion_policy_roundtrips_through_bincode() {
+        // bincode is non-self-describing (like libxmtp's store) and errors on
+        // `deserialize_any`, so an `#[serde(untagged)]` deserializer would fail
+        // here. This is the regression guard for the #2051 trap.
+        for policy in [
+            PastEpochDeletionPolicy::MaxEpochs(0),
+            PastEpochDeletionPolicy::MaxEpochs(42),
+            PastEpochDeletionPolicy::KeepAll,
+        ] {
+            let bytes = bincode::serialize(&policy).unwrap();
+            let deserialized: PastEpochDeletionPolicy = bincode::deserialize(&bytes).unwrap();
+            assert_eq!(deserialized, policy);
+        }
     }
 }

--- a/openmls/src/group/mls_group/past_secrets.rs
+++ b/openmls/src/group/mls_group/past_secrets.rs
@@ -28,7 +28,25 @@ pub(crate) struct EpochTree {
 
 /// Can store message secrets for up to `max_epochs`. The trees are added with [`self::add()`] and can be queried
 /// with [`Self::get_epoch()`].
-#[derive(Serialize, Deserialize)]
+///
+/// Persisted on-disk format. The bincode/postcard positional wire layout is:
+///
+/// ```text
+///   max_epochs:          usize
+///   past_epoch_trees:    VecDeque<EpochTree>
+///   message_secrets:     MessageSecrets            (five upstream-0.7.x fields)
+///   added_at:            Option<SystemTime>        <- fork-only trailing field
+///   past_epoch_added_at: Vec<Option<SystemTime>>   <- fork-only trailing field
+/// ```
+///
+/// The two fork-only fields are hand-serialized here rather than as an inline
+/// `MessageSecrets.added_at`, because `MessageSecrets` is not the last field of
+/// `EpochTree`, so an inline trailing field would corrupt the byte stream. They
+/// are read *tolerantly*: EOF (or any deserialize error) past the upstream shape
+/// is treated as "absent -> `None`", so data written by openmls-0.7.x — which
+/// lacks them — still loads. On deserialize the timestamps are re-hydrated onto
+/// the corresponding `MessageSecrets.added_at` fields. Both are at the end of
+/// the struct, so a tolerant misread cannot consume a sibling's bytes.
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecretsStore {
@@ -39,6 +57,123 @@ pub(crate) struct MessageSecretsStore {
     past_epoch_trees: VecDeque<EpochTree>,
     // The message secrets of the current epoch.
     message_secrets: MessageSecrets,
+}
+
+impl Serialize for MessageSecretsStore {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("MessageSecretsStore", 5)?;
+        s.serialize_field("max_epochs", &self.max_epochs)?;
+        s.serialize_field("past_epoch_trees", &self.past_epoch_trees)?;
+        s.serialize_field("message_secrets", &self.message_secrets)?;
+        s.serialize_field("added_at", &self.message_secrets.added_at)?;
+        let past_added_at: Vec<Option<SystemTime>> = self
+            .past_epoch_trees
+            .iter()
+            .map(|t| t.message_secrets.added_at)
+            .collect();
+        s.serialize_field("past_epoch_added_at", &past_added_at)?;
+        s.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for MessageSecretsStore {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        const FIELDS: &[&str] = &[
+            "max_epochs",
+            "past_epoch_trees",
+            "message_secrets",
+            "added_at",
+            "past_epoch_added_at",
+        ];
+        deserializer.deserialize_struct("MessageSecretsStore", FIELDS, MessageSecretsStoreVisitor)
+    }
+}
+
+struct MessageSecretsStoreVisitor;
+
+impl<'de> serde::de::Visitor<'de> for MessageSecretsStoreVisitor {
+    type Value = MessageSecretsStore;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("struct MessageSecretsStore")
+    }
+
+    fn visit_seq<A: serde::de::SeqAccess<'de>>(
+        self,
+        mut seq: A,
+    ) -> Result<MessageSecretsStore, A::Error> {
+        use serde::de::Error;
+        let max_epochs = seq
+            .next_element::<usize>()?
+            .ok_or_else(|| Error::missing_field("max_epochs"))?;
+        let mut past_epoch_trees = seq
+            .next_element::<VecDeque<EpochTree>>()?
+            .ok_or_else(|| Error::missing_field("past_epoch_trees"))?;
+        let mut message_secrets = seq
+            .next_element::<MessageSecrets>()?
+            .ok_or_else(|| Error::missing_field("message_secrets"))?;
+        // Tolerant tail #1: `added_at` for the current `message_secrets`.
+        let added_at = seq
+            .next_element::<Option<SystemTime>>()
+            .unwrap_or(None)
+            .flatten();
+        message_secrets.added_at = added_at;
+        // Tolerant tail #2: per-past-epoch timestamps, re-hydrated by index.
+        let past_added_at: Vec<Option<SystemTime>> = seq
+            .next_element::<Vec<Option<SystemTime>>>()
+            .unwrap_or(None)
+            .unwrap_or_default();
+        for (i, tree) in past_epoch_trees.iter_mut().enumerate() {
+            tree.message_secrets.added_at = past_added_at.get(i).copied().unwrap_or(None);
+        }
+        Ok(MessageSecretsStore {
+            max_epochs,
+            past_epoch_trees,
+            message_secrets,
+        })
+    }
+
+    fn visit_map<A: serde::de::MapAccess<'de>>(
+        self,
+        mut map: A,
+    ) -> Result<MessageSecretsStore, A::Error> {
+        use serde::de::Error;
+        let mut max_epochs: Option<usize> = None;
+        let mut past_epoch_trees: Option<VecDeque<EpochTree>> = None;
+        let mut message_secrets: Option<MessageSecrets> = None;
+        let mut added_at: Option<Option<SystemTime>> = None;
+        let mut past_epoch_added_at: Option<Vec<Option<SystemTime>>> = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "max_epochs" => max_epochs = Some(map.next_value()?),
+                "past_epoch_trees" => past_epoch_trees = Some(map.next_value()?),
+                "message_secrets" => message_secrets = Some(map.next_value()?),
+                "added_at" => added_at = Some(map.next_value()?),
+                "past_epoch_added_at" => past_epoch_added_at = Some(map.next_value()?),
+                _ => {
+                    let _: serde::de::IgnoredAny = map.next_value()?;
+                }
+            }
+        }
+
+        let mut message_secrets =
+            message_secrets.ok_or_else(|| Error::missing_field("message_secrets"))?;
+        message_secrets.added_at = added_at.unwrap_or(None);
+        let mut past_epoch_trees =
+            past_epoch_trees.ok_or_else(|| Error::missing_field("past_epoch_trees"))?;
+        if let Some(past_added_at) = past_epoch_added_at {
+            for (i, tree) in past_epoch_trees.iter_mut().enumerate() {
+                tree.message_secrets.added_at = past_added_at.get(i).copied().unwrap_or(None);
+            }
+        }
+        Ok(MessageSecretsStore {
+            max_epochs: max_epochs.ok_or_else(|| Error::missing_field("max_epochs"))?,
+            past_epoch_trees,
+            message_secrets,
+        })
+    }
 }
 
 #[cfg(not(feature = "crypto-debug"))]
@@ -338,5 +473,95 @@ impl MessageSecretsStore {
     /// Helper function for testing, to get the number of past epoch trees
     pub(crate) fn num_past_epoch_trees(&self) -> usize {
         self.past_epoch_trees.len()
+    }
+}
+
+// Storage-compatibility tests for the fork-only `added_at` tail, exercised
+// through *bincode* — the non-self-describing codec libxmtp actually persists
+// with. The existing `past_secrets_storage_compatibility` KAT uses `serde_json`
+// (self-describing), so it only covers the `visit_map` path; these cover the
+// `visit_seq` / EOF-tolerant path that motivates the hand-written impl.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod bincode_storage_compat_tests {
+    use super::{EpochTree, MessageSecretsStore};
+    use crate::binary_tree::array_representation::LeafNodeIndex;
+    use crate::group::mls_group::config::PastEpochDeletionPolicy;
+    use crate::schedule::message_secrets::MessageSecrets;
+    use openmls_rust_crypto::RustCrypto;
+    use openmls_traits::types::Ciphersuite;
+    use serde::Serialize;
+    use std::collections::VecDeque;
+    use std::time::SystemTime;
+
+    const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+    fn secrets(rng: &RustCrypto, added_at: Option<SystemTime>) -> MessageSecrets {
+        MessageSecrets::random(CIPHERSUITE, rng, LeafNodeIndex::new(0)).with_timestamp(added_at)
+    }
+
+    /// A new-format `MessageSecretsStore` round-trips through bincode, preserving
+    /// the fork-only `added_at` timestamps carried on the trailing tail fields —
+    /// both the current secrets and each past epoch.
+    #[test]
+    fn bincode_roundtrip_preserves_added_at() {
+        let rng = RustCrypto::default();
+        let mut store = MessageSecretsStore::new_with_secret(
+            &PastEpochDeletionPolicy::KeepAll,
+            secrets(&rng, None),
+        );
+        store.add_past_epoch_tree(0u64, secrets(&rng, None), Vec::new());
+        store.add_past_epoch_tree(1u64, secrets(&rng, None), Vec::new());
+
+        // Set known timestamps directly, bypassing the `SystemTime::now()` the
+        // constructors stamp. Mix in a `None` so the parallel
+        // `past_epoch_added_at` array is exercised on both a present and an
+        // absent entry.
+        let current = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000);
+        let past0 = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(2_000);
+        store.message_secrets.added_at = Some(current);
+        store.past_epoch_trees[0].message_secrets.added_at = Some(past0);
+        store.past_epoch_trees[1].message_secrets.added_at = None;
+
+        let bytes = bincode::serialize(&store).expect("serialize");
+        let back: MessageSecretsStore = bincode::deserialize(&bytes).expect("deserialize");
+
+        assert_eq!(back.message_secrets.added_at, Some(current));
+        assert_eq!(
+            back.past_epoch_trees[0].message_secrets.added_at,
+            Some(past0)
+        );
+        assert_eq!(back.past_epoch_trees[1].message_secrets.added_at, None);
+    }
+
+    /// Data written before `added_at` existed (openmls-0.7.x, as shipped in
+    /// libxmtp 1.9/1.10) has only the three base fields under bincode. The
+    /// trailing tail fields must read tolerantly — EOF -> `None`, not an error.
+    #[test]
+    fn bincode_tolerates_pre_added_at_layout() {
+        let rng = RustCrypto::default();
+        let store = MessageSecretsStore::new_with_secret(
+            &PastEpochDeletionPolicy::KeepAll,
+            secrets(&rng, Some(SystemTime::now())),
+        );
+
+        // The openmls-0.7.x on-disk shape: the three base fields only, no
+        // trailing `added_at` / `past_epoch_added_at`. bincode is positional, so
+        // this is byte-identical to what an older openmls wrote.
+        #[derive(Serialize)]
+        struct PreAddedAtLayout<'a> {
+            max_epochs: usize,
+            past_epoch_trees: &'a VecDeque<EpochTree>,
+            message_secrets: &'a MessageSecrets,
+        }
+        let old_bytes = bincode::serialize(&PreAddedAtLayout {
+            max_epochs: store.max_epochs,
+            past_epoch_trees: &store.past_epoch_trees,
+            message_secrets: &store.message_secrets,
+        })
+        .expect("serialize old layout");
+
+        let back: MessageSecretsStore =
+            bincode::deserialize(&old_bytes).expect("deserialize old layout");
+        assert!(back.message_secrets.added_at.is_none());
     }
 }

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -1098,7 +1098,30 @@ impl StagedCommit {
 }
 
 /// This struct is used internally by [`StagedCommit`] to encapsulate all the modified group state.
-#[derive(Debug, Serialize, Deserialize)]
+//
+// IMPORTANT: this struct is reachable from the persisted on-disk format
+// (`MlsGroupState::PendingCommit(..)` -> `PendingCommitState::Member(..)` ->
+// `StagedCommit::state` -> `StagedCommitState::GroupMember(..)`). The first six
+// fields are the openmls-0.7.x shape and MUST NOT be reordered or have fields
+// inserted between them. The feature-gated `application_export_tree` and
+// `new_own_leaf_index` are trailing fields deserialized *tolerantly* (EOF ->
+// absent -> `None`) via the custom impl below, so data written by an older
+// openmls — before the field existed — still loads. `#[serde(default)]` does
+// not achieve this: bincode is positional and ignores it. They stay at the end
+// and are read in declaration order, so a tolerant misread cannot consume a
+// sibling's bytes.
+//
+// The tail layout under a positional codec is per feature combination: data
+// loads correctly only when the writer's enabled tail fields form a prefix, in
+// declaration order, of the reader's (e.g. no-features data read anywhere, or
+// `extensions-draft` data read by a build with both features). A non-prefix
+// combination would misalign the slots, but none is buildable:
+// `virtual-clients-draft` enables `extensions-draft` in Cargo.toml, so the
+// possible feature sets are exactly the prefixes of the declaration order.
+// This constraint is inherent to cfg-gated persisted fields (upstream's derive
+// has it too); when adding a tail field behind a new feature, declare it last
+// and give the feature the same Cargo dependency on its predecessors.
+#[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
 pub(crate) struct MemberStagedCommitState {
     group_epoch_secrets: GroupEpochSecrets,
@@ -1107,18 +1130,172 @@ pub(crate) struct MemberStagedCommitState {
     new_keypairs: Vec<EncryptionKeyPair>,
     new_leaf_keypair_option: Option<EncryptionKeyPair>,
     update_path_leaf_node: Option<LeafNode>,
-    #[cfg(feature = "extensions-draft")]
-    #[serde(default)]
     // This is `None` only if the group was stored using an older version of
     // OpenMLS that did not support the application exporter.
+    #[cfg(feature = "extensions-draft")]
     application_export_tree: Option<ApplicationExportTree>,
     // The new leaf index to install on the receiving group at merge time
     // when this staged commit is a sibling-resync external commit (a VC
     // external commit from a sibling emulator that inline-removes the
     // receiver's existing leaf). `None` for all other commit kinds.
     #[cfg(feature = "virtual-clients-draft")]
-    #[serde(default)]
     new_own_leaf_index: Option<LeafNodeIndex>,
+}
+
+const MEMBER_STAGED_COMMIT_STATE_FIELDS: &[&str] = &[
+    "group_epoch_secrets",
+    "message_secrets",
+    "staged_diff",
+    "new_keypairs",
+    "new_leaf_keypair_option",
+    "update_path_leaf_node",
+    #[cfg(feature = "extensions-draft")]
+    "application_export_tree",
+    #[cfg(feature = "virtual-clients-draft")]
+    "new_own_leaf_index",
+];
+
+impl Serialize for MemberStagedCommitState {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct(
+            "MemberStagedCommitState",
+            MEMBER_STAGED_COMMIT_STATE_FIELDS.len(),
+        )?;
+        s.serialize_field("group_epoch_secrets", &self.group_epoch_secrets)?;
+        s.serialize_field("message_secrets", &self.message_secrets)?;
+        s.serialize_field("staged_diff", &self.staged_diff)?;
+        s.serialize_field("new_keypairs", &self.new_keypairs)?;
+        s.serialize_field("new_leaf_keypair_option", &self.new_leaf_keypair_option)?;
+        s.serialize_field("update_path_leaf_node", &self.update_path_leaf_node)?;
+        #[cfg(feature = "extensions-draft")]
+        s.serialize_field("application_export_tree", &self.application_export_tree)?;
+        #[cfg(feature = "virtual-clients-draft")]
+        s.serialize_field("new_own_leaf_index", &self.new_own_leaf_index)?;
+        s.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for MemberStagedCommitState {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_struct(
+            "MemberStagedCommitState",
+            MEMBER_STAGED_COMMIT_STATE_FIELDS,
+            MemberStagedCommitStateVisitor,
+        )
+    }
+}
+
+struct MemberStagedCommitStateVisitor;
+
+impl<'de> serde::de::Visitor<'de> for MemberStagedCommitStateVisitor {
+    type Value = MemberStagedCommitState;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("struct MemberStagedCommitState")
+    }
+
+    fn visit_seq<A: serde::de::SeqAccess<'de>>(
+        self,
+        mut seq: A,
+    ) -> Result<MemberStagedCommitState, A::Error> {
+        use serde::de::Error;
+        let group_epoch_secrets = seq
+            .next_element::<GroupEpochSecrets>()?
+            .ok_or_else(|| Error::missing_field("group_epoch_secrets"))?;
+        let message_secrets = seq
+            .next_element::<MessageSecrets>()?
+            .ok_or_else(|| Error::missing_field("message_secrets"))?;
+        let staged_diff = seq
+            .next_element::<StagedPublicGroupDiff>()?
+            .ok_or_else(|| Error::missing_field("staged_diff"))?;
+        let new_keypairs = seq
+            .next_element::<Vec<EncryptionKeyPair>>()?
+            .ok_or_else(|| Error::missing_field("new_keypairs"))?;
+        let new_leaf_keypair_option = seq
+            .next_element::<Option<EncryptionKeyPair>>()?
+            .ok_or_else(|| Error::missing_field("new_leaf_keypair_option"))?;
+        let update_path_leaf_node = seq
+            .next_element::<Option<LeafNode>>()?
+            .ok_or_else(|| Error::missing_field("update_path_leaf_node"))?;
+        // Tolerant tail reads, in declaration order. Each may be absent in data
+        // written by an older openmls or a build without the feature; any error
+        // (e.g. bincode EOF) is treated as "field absent -> None".
+        #[cfg(feature = "extensions-draft")]
+        let application_export_tree = seq
+            .next_element::<Option<ApplicationExportTree>>()
+            .unwrap_or(None)
+            .flatten();
+        #[cfg(feature = "virtual-clients-draft")]
+        let new_own_leaf_index = seq
+            .next_element::<Option<LeafNodeIndex>>()
+            .unwrap_or(None)
+            .flatten();
+        Ok(MemberStagedCommitState {
+            group_epoch_secrets,
+            message_secrets,
+            staged_diff,
+            new_keypairs,
+            new_leaf_keypair_option,
+            update_path_leaf_node,
+            #[cfg(feature = "extensions-draft")]
+            application_export_tree,
+            #[cfg(feature = "virtual-clients-draft")]
+            new_own_leaf_index,
+        })
+    }
+
+    fn visit_map<A: serde::de::MapAccess<'de>>(
+        self,
+        mut map: A,
+    ) -> Result<MemberStagedCommitState, A::Error> {
+        use serde::de::Error;
+        let mut group_epoch_secrets: Option<GroupEpochSecrets> = None;
+        let mut message_secrets: Option<MessageSecrets> = None;
+        let mut staged_diff: Option<StagedPublicGroupDiff> = None;
+        let mut new_keypairs: Option<Vec<EncryptionKeyPair>> = None;
+        let mut new_leaf_keypair_option: Option<Option<EncryptionKeyPair>> = None;
+        let mut update_path_leaf_node: Option<Option<LeafNode>> = None;
+        #[cfg(feature = "extensions-draft")]
+        let mut application_export_tree: Option<Option<ApplicationExportTree>> = None;
+        #[cfg(feature = "virtual-clients-draft")]
+        let mut new_own_leaf_index: Option<Option<LeafNodeIndex>> = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "group_epoch_secrets" => group_epoch_secrets = Some(map.next_value()?),
+                "message_secrets" => message_secrets = Some(map.next_value()?),
+                "staged_diff" => staged_diff = Some(map.next_value()?),
+                "new_keypairs" => new_keypairs = Some(map.next_value()?),
+                "new_leaf_keypair_option" => new_leaf_keypair_option = Some(map.next_value()?),
+                "update_path_leaf_node" => update_path_leaf_node = Some(map.next_value()?),
+                #[cfg(feature = "extensions-draft")]
+                "application_export_tree" => application_export_tree = Some(map.next_value()?),
+                #[cfg(feature = "virtual-clients-draft")]
+                "new_own_leaf_index" => new_own_leaf_index = Some(map.next_value()?),
+                _ => {
+                    let _: serde::de::IgnoredAny = map.next_value()?;
+                }
+            }
+        }
+
+        Ok(MemberStagedCommitState {
+            group_epoch_secrets: group_epoch_secrets
+                .ok_or_else(|| Error::missing_field("group_epoch_secrets"))?,
+            message_secrets: message_secrets
+                .ok_or_else(|| Error::missing_field("message_secrets"))?,
+            staged_diff: staged_diff.ok_or_else(|| Error::missing_field("staged_diff"))?,
+            new_keypairs: new_keypairs.ok_or_else(|| Error::missing_field("new_keypairs"))?,
+            new_leaf_keypair_option: new_leaf_keypair_option
+                .ok_or_else(|| Error::missing_field("new_leaf_keypair_option"))?,
+            update_path_leaf_node: update_path_leaf_node
+                .ok_or_else(|| Error::missing_field("update_path_leaf_node"))?,
+            #[cfg(feature = "extensions-draft")]
+            application_export_tree: application_export_tree.unwrap_or(None),
+            #[cfg(feature = "virtual-clients-draft")]
+            new_own_leaf_index: new_own_leaf_index.unwrap_or(None),
+        })
+    }
 }
 
 impl MemberStagedCommitState {

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -654,11 +654,6 @@ impl PublicGroup {
         &self,
         proposal_queue: &ProposalQueue,
     ) -> Result<(), AppDataUpdateValidationError> {
-        let no_app_data_updates = proposal_queue.app_data_update_proposals().next().is_none();
-        if no_app_data_updates {
-            return Ok(());
-        }
-
         // retrieve the GroupContextExtensions proposal, if available
         let group_context_extension_proposal = proposal_queue
             .filtered_by_type(ProposalType::GroupContextExtensions)
@@ -667,6 +662,51 @@ impl PublicGroup {
                 _ => None,
             })
             .next();
+
+        // From https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions#section-4.7-6:
+        // When an MLS group contains the AppDataUpdate proposal type in the proposal_types list in
+        // the group's required_capabilities extension, a GroupContextExtensions proposal MUST NOT
+        // add, remove, or modify the app_data_dictionary GroupContext extension. In other words,
+        // when every member of the group supports the AppDataUpdate proposal, a
+        // GroupContextExtensions proposal could be sent to update some other extension(s), but the
+        // app_data_dictionary GroupContext extension, if it exists, is left as it was.
+        //
+        // This is checked *before* the "no AppDataUpdate proposals" early return below: the rule
+        // binds every commit that carries a GroupContextExtensions proposal, including one with no
+        // accompanying AppDataUpdate proposals. Skipping it in that case would let a bare
+        // GroupContextExtensions proposal rewrite the app_data_dictionary directly, bypassing the
+        // AppDataUpdate machinery.
+        //
+        // The rule is treated as active when the group requires AppDataUpdate either before or
+        // after the commit. Reading only the *proposed* required_capabilities would let a sender
+        // evade the check by dropping AppDataUpdate from required_capabilities in the same
+        // proposal; reading only the *current* required_capabilities would skip the migrating
+        // commit that both introduces the dictionary and adds AppDataUpdate.
+        if let Some(group_context_extension) = group_context_extension_proposal {
+            let current_requires_app_data_update = self
+                .group_context()
+                .extensions()
+                .required_capabilities()
+                .map(|rc| rc.proposal_types().contains(&ProposalType::AppDataUpdate))
+                .unwrap_or(false);
+            let proposed_requires_app_data_update = group_context_extension
+                .extensions()
+                .required_capabilities()
+                .map(|rc| rc.proposal_types().contains(&ProposalType::AppDataUpdate))
+                .unwrap_or(false);
+
+            if (current_requires_app_data_update || proposed_requires_app_data_update)
+                && group_context_extension.extensions().app_data_dictionary()
+                    != self.group_context().extensions().app_data_dictionary()
+            {
+                return Err(AppDataUpdateValidationError::CannotUpdateDictionaryDirectly);
+            }
+        }
+
+        let no_app_data_updates = proposal_queue.app_data_update_proposals().next().is_none();
+        if no_app_data_updates {
+            return Ok(());
+        }
 
         // check ordering
         // return an error if an AppDataUpdate appears before a GroupContextExtensions proposal
@@ -688,32 +728,6 @@ impl PublicGroup {
             .any(|proposal_type| proposal_type == ProposalType::GroupContextExtensions)
         {
             return Err(AppDataUpdateValidationError::IncorrectOrder);
-        }
-
-        if let Some(group_context_extension) = group_context_extension_proposal {
-            let required_capabilities_contain_app_data_update_proposal = group_context_extension
-                .extensions()
-                .required_capabilities()
-                .map(|required_capabilities| {
-                    required_capabilities
-                        .proposal_types()
-                        .contains(&ProposalType::AppDataUpdate)
-                })
-                .unwrap_or(false);
-
-            // From https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions#section-4.7-6:
-            // When an MLS group contains the AppDataUpdate proposal type in the proposal_types list in
-            // the group's required_capabilities extension, a GroupContextExtensions proposal MUST NOT
-            // add, remove, or modify the app_data_dictionary GroupContext extension. In other words,
-            // when every member of the group supports the AppDataUpdate proposal, a
-            // GroupContextExtensions proposal could be sent to update some other extension(s), but the
-            // app_data_dictionary GroupContext extension, if it exists, is left as it was.
-            if required_capabilities_contain_app_data_update_proposal
-                && group_context_extension.extensions().app_data_dictionary()
-                    != self.group_context().extensions().app_data_dictionary()
-            {
-                return Err(AppDataUpdateValidationError::CannotUpdateDictionaryDirectly);
-            }
         }
 
         // From the draft:

--- a/openmls/src/group/tests_and_kats/tests/app_data_update_proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/app_data_update_proposal_validation.rs
@@ -184,6 +184,57 @@ fn test_group_context_update_dictionary() {
 }
 
 /// Commit creation:
+/// Regression: a GroupContextExtensions proposal that modifies the AppDataDictionary MUST be
+/// rejected even when the commit carries NO AppDataUpdate proposals. Otherwise a bare
+/// GroupContextExtensions proposal bypasses the AppDataUpdate machinery and rewrites the
+/// dictionary directly, in violation of draft-ietf-mls-extensions §4.7-6.
+#[openmls_test]
+fn test_group_context_update_dictionary_without_app_data_update() {
+    // Set up parties
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+
+    let mut group_state = setup(&alice_party, &bob_party, ciphersuite, true);
+
+    let [alice] = group_state.members_mut(&["alice"]);
+
+    let required_capabilities_extension =
+        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
+            &[ExtensionType::AppDataDictionary],
+            &[ProposalType::AppDataUpdate],
+            &[],
+        ));
+
+    let dictionary_extension = Extension::AppDataDictionary(AppDataDictionaryExtension::default());
+
+    // Bare GroupContextExtensions proposal that touches the dictionary, with NO accompanying
+    // AppDataUpdate proposal.
+    alice
+        .group
+        .propose_group_context_extensions(
+            &alice_party.provider,
+            Extensions::from_vec(vec![required_capabilities_extension, dictionary_extension])
+                .unwrap(),
+            &alice.party.signer,
+        )
+        .unwrap();
+
+    let err = alice
+        .group
+        .commit_to_pending_proposals(&alice_party.provider, &alice.party.signer)
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        CommitToPendingProposalsError::CreateCommitError(
+            CreateCommitError::AppDataUpdateValidationError(
+                AppDataUpdateValidationError::CannotUpdateDictionaryDirectly
+            )
+        )
+    );
+}
+
+/// Commit creation:
 /// Test the case where a GroupContextExtensionProposal updates the AppDataDictionary after
 /// removing AppDataUpdate from the required capabilities.
 #[openmls_test]

--- a/openmls/src/schedule/message_secrets.rs
+++ b/openmls/src/schedule/message_secrets.rs
@@ -17,11 +17,22 @@ pub(crate) struct MessageSecrets {
     confirmation_key: ConfirmationKey,
     serialized_context: Vec<u8>,
     secret_tree: SecretTree,
-    /// When the secrets were added to the store
-    /// `None` if no timestamp is available
+    /// When the secrets were added to the store.
+    ///
+    /// `None` if no timestamp is available — including when reading data that
+    /// predates this field.
+    ///
+    /// Skipped during serde and persisted out-of-band as a trailing, tolerantly
+    /// read field on the containing [`MessageSecretsStore`] (see its `Serialize`
+    /// / `Deserialize` impl). This keeps `MessageSecrets` byte-identical to the
+    /// openmls-0.7.x five-field shape under bincode, so `EpochTree` — where
+    /// `MessageSecrets` is *not* the last field — still round-trips. Serializing
+    /// it inline with `#[serde(default)]` does not work: bincode is positional
+    /// and ignores `default`, so 0.7.x data hits EOF on the missing field.
+    ///
     /// NOTE: SystemTime is not guaranteed to be monotonic.
-    #[serde(default)]
-    added_at: Option<SystemTime>,
+    #[serde(skip)]
+    pub(crate) added_at: Option<SystemTime>,
 }
 
 #[cfg(not(feature = "crypto-debug"))]


### PR DESCRIPTION
Replays the fork's persisted-storage divergence on top of the merged upstream main (#55), as four focused commits, plus a fifth commit replaying the open upstream security fix openmls/openmls#2125. #55 brought the code up to upstream; this PR makes the storage format read/write-compatible with what shipped fork releases (and the libxmtp versions pinned to them) actually persisted. libxmtp persists these structures with **bincode** — non-self-describing and positional — which drives every choice below.

## Commits

**1. Restore persisted `storage_tag` numbering on `ExtensionType` and `Extension`**
The fork's `ImmutableMetadata` occupies tag 6, shifting `Unknown`/`Grease`/`AppDataDictionary` to 7/8/9 (`Extension`: 6/7/8). This matches the numbering every shipped fork release persisted. Declaration order is untouched — `ImmutableMetadata` stays declared last — so the `0-8-1-storage-format` positional path keeps upstream's indices.

**2. Add a fork storage-tag baseline to `compat_tests`**
The fork's numbering can never match a published openmls crate, so a new suite pins it positively instead. Upstream's published-crate comparison for these two enums is re-gated to the positional `compat_0_8_1*` runs, where it still holds. A new `fork-baseline` feature covers `AppDataDictionary`'s tag with `extensions-draft` on; `test.sh` runs it.

**3. Encode `PastEpochDeletionPolicy` as a portable, bincode-safe `u64`**
Upstream #2051's `#[serde(untagged)]` deserializer requires `Deserializer::deserialize_any`, which bincode errors on — every group-config load fails at runtime. Upstream's tests miss it because they use serde_json. This restores the fork's encoding verbatim: plain `u64`, `KeepAll` = `u64::MAX` (not `usize::MAX as u64`, which differs on wasm32). The plain `u64` is load-bearing twice over: it is also byte-identical to the pre-rename `max_past_epochs: usize` at the same struct position, so config data written by libxmtp 1.9/1.10 (openmls `beb0884d`, before this type existed) loads unchanged. A bincode round-trip test guards against regression to `untagged`.

**4. Tolerantly deserialize fork-only trailing fields on persisted structs**
Restores the fork's hand-written serde for `MessageSecretsStore` and `MemberStagedCommitState`. `MessageSecrets.added_at` is `#[serde(skip)]` and carried as trailing fields on the containing store, read tolerantly (EOF → absent → `None`) — `#[serde(default)]` cannot do this because bincode is positional and ignores it. Data written before the fields existed (openmls 0.7.x, libxmtp 1.9/1.10) still loads; the tails sit at the terminal position of their storage blobs, so a tolerant misread can never consume a sibling's bytes. New bincode tests cover the non-self-describing path — the existing storage-compatibility KAT uses serde_json and only exercises `visit_map`.

**5. Enforce `app_data_dictionary` immutability for bare `GroupContextExtensions` proposals**
Replay of open upstream PR openmls/openmls#2125. The dictionary-immutability check ran after the no-`AppDataUpdate` early return, so a commit carrying only a `GroupContextExtensions` proposal could rewrite the `app_data_dictionary` directly, bypassing the `AppDataUpdate` machinery. The check now runs ahead of the early return and triggers when either the current or the proposed `required_capabilities` contains `AppDataUpdate` — a sender can neither evade it by dropping `AppDataUpdate` in the same proposal nor slip past on the migrating commit. Drop at the upstream merge after #2125 lands.

## Compatibility

| Written by | Read by this branch |
| --- | --- |
| libxmtp 1.9/1.10 (openmls `beb0884d`: no `added_at`, `max_past_epochs: usize`) | loads; `added_at` → `None`, `max_past_epochs` → `MaxEpochs(n)` |
| fork main pre-#55 (`e125674`) | byte-identical encodings; loads unchanged |
| this branch | round-trips |

## Verification

- Full lib suite: 266 passed (default), 309 passed (`extensions-draft`), 0 failed
- `compat_tests/test.sh`: all four variants green (`compat_0_7_1`, `compat_0_8_1`, `compat_0_8_1_extensions`, `fork-baseline`)
- clippy clean (default and `extensions-draft`, all targets); `cargo fmt --check` clean
- `virtual-clients-draft` and `virtual-clients-draft,extensions-draft` compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Replays the fork's persisted-storage divergence on top of the merged upstream main (#55), as four focused commits, plus a fifth commit replaying the open upstream security fix openmls/openmls#2125. #55 brought the code up to upstream; this PR makes the storage format read/write-compatible with what shipped fork releases (and the libxmtp versions pinned to them) actually persisted. libxmtp persists these structures with **bincode** — non-self-describing and positional — which drives every choice below.
>
> ## Commits
>
> **1. Restore persisted `storage_tag` numbering on `ExtensionType` and `Extension`**
> The fork's `ImmutableMetadata` occupies tag 6, shifting `Unknown`/`Grease`/`AppDataDictionary` to 7/8/9 (`Extension`: 6/7/8). This matches the numbering every shipped fork release persisted. Declaration order is untouched — `ImmutableMetadata` stays declared last — so the `0-8-1-storage-format` positional path keeps upstream's indices.
>
> **2. Add a fork storage-tag baseline to `compat_tests`**
> The fork's numbering can never match a published openmls crate, so a new suite pins it positively instead. Upstream's published-crate comparison for these two enums is re-gated to the positional `compat_0_8_1*` runs, where it still holds. A new `fork-baseline` feature covers `AppDataDictionary`'s tag with `extensions-draft` on; `test.sh` runs it.
>
> **3. Encode `PastEpochDeletionPolicy` as a portable, bincode-safe `u64`**
> Upstream #2051's `#[serde(untagged)]` deserializer requires `Deserializer::deserialize_any`, which bincode errors on — every group-config load fails at runtime. Upstream's tests miss it because they use serde_json. This restores the fork's encoding verbatim: plain `u64`, `KeepAll` = `u64::MAX` (not `usize::MAX as u64`, which differs on wasm32). The plain `u64` is load-bearing twice over: it is also byte-identical to the pre-rename `max_past_epochs: usize` at the same struct position, so config data written by libxmtp 1.9/1.10 (openmls `beb0884d`, before this type existed) loads unchanged. A bincode round-trip test guards against regression to `untagged`.
>
> **4. Tolerantly deserialize fork-only trailing fields on persisted structs**
> Restores the fork's hand-written serde for `MessageSecretsStore` and `MemberStagedCommitState`. `MessageSecrets.added_at` is `#[serde(skip)]` and carried as trailing fields on the containing store, read tolerantly (EOF → absent → `None`) — `#[serde(default)]` cannot do this because bincode is positional and ignores it. Data written before the fields existed (openmls 0.7.x, libxmtp 1.9/1.10) still loads; the tails sit at the terminal position of their storage blobs, so a tolerant misread can never consume a sibling's bytes. New bincode tests cover the non-self-describing path — the existing storage-compatibility KAT uses serde_json and only exercises `visit_map`.
>
> **5. Enforce `app_data_dictionary` immutability for bare `GroupContextExtensions` proposals**
> Replay of open upstream PR openmls/openmls#2125. The dictionary-immutability check ran after the no-`AppDataUpdate` early return, so a commit carrying only a `GroupContextExtensions` proposal could rewrite the `app_data_dictionary` directly, bypassing the `AppDataUpdate` machinery. The check now runs ahead of the early return and triggers when either the current or the proposed `required_capabilities` contains `AppDataUpdate` — a sender can neither evade it by dropping `AppDataUpdate` in the same proposal nor slip past on the migrating commit. Drop at the upstream merge after #2125 lands.
>
> ## Compatibility
>
> | Written by | Read by this branch |
> | --- | --- |
> | libxmtp 1.9/1.10 (openmls `beb0884d`: no `added_at`, `max_past_epochs: usize`) | loads; `added_at` → `None`, `max_past_epochs` → `MaxEpochs(n)` |
> | fork main pre-#55 (`e125674`) | byte-identical encodings; loads unchanged |
> | this branch | round-trips |
>
> ## Verification
>
> - Full lib suite: 266 passed (default), 309 passed (`extensions-draft`), 0 failed
> - `compat_tests/test.sh`: all four variants green (`compat_0_7_1`, `compat_0_8_1`, `compat_0_8_1_extensions`, `fork-baseline`)
> - clippy clean (default and `extensions-draft`, all targets); `cargo fmt --check` clean
> - `virtual-clients-draft` and `virtual-clients-draft,extensions-draft` compile
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
> <!-- Macroscope's changelog starts here -->
> #### Changes since #56 opened
>
> - Modified validation logic in `PublicGroup.validate_app_data_update_proposals_and_group_context` to reject commits when `GroupContextExtensions` proposal modifies `app_data_dictionary` if either current or proposed `required_capabilities` includes `AppDataUpdate` proposal type [d87680e]
> - Added test `test_group_context_update_dictionary_without_app_data_update` validating rejection of `GroupContextExtensions` proposal that modifies `AppDataDictionary` without `AppDataUpdate` proposals [d87680e]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->